### PR TITLE
Use CKEditor for Dynamic Content

### DIFF
--- a/src/dynamicContent/dynamicContent.commands.js
+++ b/src/dynamicContent/dynamicContent.commands.js
@@ -17,6 +17,14 @@ export default class DynamicContentCommands {
 
   // eslint-disable-next-line class-methods-use-this
   stopDynamicContentPopup() {
+    // Destroy Dynamic Content editors and write the contents to the textarea
+    for (const name of Object.keys(CKEDITOR.instances)) {
+      if (name.includes('dynamicContent')) {
+        this.logger.debug(`Destroying Dynamic Content editor: ${name}`);
+        CKEDITOR.instances[name].destroy(false);
+      }
+    }
+
     this.dcService.updateDcStoreItem();
   }
 
@@ -90,6 +98,20 @@ export default class DynamicContentCommands {
 
     editor.Modal.setContent(this.dcPopup);
     modal.open();
+
+    // Set up dynamic content editors if present
+    Mautic.setDynamicContentEditors(Mautic.getBuilderContainer());
+
+    // When a new Dynamic Content filter (tab) is added, we want to turn the editor into CKEditor.
+    Mautic.dynamicContentAddNewFilterListener((textarea) => {
+      Mautic.ConvertFieldToCkeditor(textarea, {});
+    });
+
+    // When a new Dynamic Content item (slot) is added, we want to turn the editor into CKEditor.
+    Mautic.dynamicContentAddNewItemListener((textarea) => {
+      Mautic.ConvertFieldToCkeditor(textarea, {});
+    });
+
     modal.onceClose(() => editor.stopCommand('preset-mautic:dynamic-content-open'));
   }
 


### PR DESCRIPTION
Needs https://github.com/mautic/mautic/pull/10114

This PR uses CKEditor to edit Dynamic Content. As soon as the Dynamic Content popup is opened, we turn it into a CKEditor using the newly introduced `Mautic.setDynamicContentEditors()`. The same goes for when new filters or items are added to an existing Dynamic Content item.

https://user-images.githubusercontent.com/17739158/129384733-6a38d76a-c6d6-4056-91f7-6d06434a6b1e.mp4

We might want to introduce a function in the `Mautic` namespace later that can destroy the CKEditor as well, so we abstract that away from the builder itself.