### PR TITLE
Sanitize page content using `Mautic.sanitizeHtmlBeforeSave()`

### DIFF
--- a/dist/content.service.js
+++ b/dist/content.service.js
@@ -34,6 +34,12 @@ export default class ContentService {
 
     const originalContent = ContentService.getOriginalContentHtml();
     const doctype = ContentService.serializeDoctype(originalContent.doctype);
+    /**
+     * Sanitize the content. This updates the originalContent variable directly
+     * (as it's passed by reference), so we don't need to re-assign anything here
+     */
+
+    Mautic.sanitizeHtmlBeforeSave(mQuery(originalContent));
     const htmlCombined = `${doctype}${editor.getHtml()}<style>${editor.getCss({
       avoidProtected: true
     })}</style>`;

--- a/src/content.service.js
+++ b/src/content.service.js
@@ -43,6 +43,12 @@ export default class ContentService {
     const originalContent = ContentService.getOriginalContentHtml();
     const doctype = ContentService.serializeDoctype(originalContent.doctype);
 
+    /**
+     * Sanitize the content. This updates the originalContent variable directly
+     * (as it's passed by reference), so we don't need to re-assign anything here
+     */
+    Mautic.sanitizeHtmlBeforeSave(mQuery(originalContent));
+
     const htmlCombined = `${doctype}${editor.getHtml()}<style>${editor.getCss({
       avoidProtected: true,
     })}</style>`;


### PR DESCRIPTION
Fixes https://github.com/mautic/mautic/issues/9998 (see https://github.com/mautic/mautic/issues/9998#issuecomment-898915035 specifically for more context)

Some technical context on this PR:
- `originalContent` is an HTMLDocument object
- `Mautic.sanitizeHtmlBeforeSave()` expects a jQuery object and returns a string
  - We can turn `originalContent` into a jQuery object by simply doing `mQuery(originalContent)`
  - We can't use the string that this function outputs, as consuming functions expect an HTMLDocument, not a string
  - Because `originalContent` is passed by reference, Mautic's function will __update__ the existing `originalContent` variable, so we don't have to re-assign anything there 🎉 

Before this change, HTML head JS/CSS tags with `data-source="mautic"` would incorrectly end up in the database:

![image](https://user-images.githubusercontent.com/17739158/130503980-114351ae-26a0-4438-8ae1-05fb512a0b0d.png)

After this change, HTML head JS/CSS tags don't end up in the database anymore, except the ones that are explicitly defined in the theme (`/nonexistent.js` in this case):

![image](https://user-images.githubusercontent.com/17739158/130504083-54b33bb2-a420-4020-923b-10866834198a.png)

