### PR TITLE
remove strict mode, add cleanId option to getHtml

### DIFF
--- a/dist/mjml/mjml.service.js
+++ b/dist/mjml/mjml.service.js
@@ -38,7 +38,10 @@ export default class MjmlService {
 
 
   static getEditorMjmlContent(editor) {
-    return editor.getHtml().trim();
+    // cleanId: Remove unnecessary IDs (eg. those created automatically)
+    return editor.getHtml({
+      cleanId: true
+    }).trim();
   }
   /**
    * Transform MJML to HTML
@@ -50,12 +53,11 @@ export default class MjmlService {
   static mjmlToHtml(mjml) {
     try {
       if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
-        throw new Error('No valid MJML string');
+        throw new Error('No valid MJML provided');
       } // html needs to be beautified for the click tracking to work.
 
 
       return mjml2html(mjml, {
-        validationLevel: 'strict',
         beautify: true
       });
     } catch (error) {

--- a/src/mjml/mjml.service.js
+++ b/src/mjml/mjml.service.js
@@ -37,7 +37,8 @@ export default class MjmlService {
    * @returns string
    */
   static getEditorMjmlContent(editor) {
-    return editor.getHtml().trim();
+    // cleanId: Remove unnecessary IDs (eg. those created automatically)
+    return editor.getHtml({ cleanId: true }).trim();
   }
 
   /**
@@ -48,10 +49,10 @@ export default class MjmlService {
   static mjmlToHtml(mjml) {
     try {
       if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
-        throw new Error('No valid MJML string');
+        throw new Error('No valid MJML provided');
       }
       // html needs to be beautified for the click tracking to work.
-      return mjml2html(mjml, { validationLevel: 'strict', beautify: true });
+      return mjml2html(mjml, { beautify: true });
     } catch (error) {
       console.warn(error);
       return null;


### PR DESCRIPTION
Workaround for the issue https://github.com/mautic/mautic/issues/10398 with the invalid ids on mjml elements like <mj-imag>
```mjml
<mj-image src="http://mautic.ddev.site/media/images/smiling-woman.jpg" id="ih9jb" />
```

In order to get it to work I added the `cleanId` option to getHtml(). But this had no effect on the image. I left the code in place because I think it is a good idea to not have unnecessary ids.

Since the problem still exists I see two options: 
A) Use the regex workaround to remove all id's from all elements
B) Remove strict mode
C) Investigate and fix the issue of why unnecessary ids are added in the first place

While C) is my preferred solution this is something that has to be done in the Grapesjs project and will be the most time-consuming. 

A) is risky as it can lead to other unwanted results.

So I went with B)
I removed the strict mode for now. This should only be a temporary fix until we have option C). We should still fix all the issues we have with the current MJML enabled themes in the codebase. 

As this is a very small code change and we need to test it in the Mautic/mautic repo as well I suggest we do a code review only.