### PR TITLE
Added preference center blocks to GrapesJS builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,6 @@ Html needs to be `beautified` for the click tracking to work. Therefore, we can 
 > `beautify` option is deprecated in mjml-core and only available in mjml cli.
 https://github.com/mautic/mautic/issues/10331
 
-### Dynamic Content
-- Takes HTML from the Dynamic Content popup and adds it to the canvas based on the text (html) or mj-text (mjml) component.
-
 ## How to test a preset pull request
 
 1. Build the preset: `npm run build` (done by author)

--- a/dist/blocks.js
+++ b/dist/blocks.js
@@ -1,6 +1,7 @@
 import DynamicContentBlocks from './dynamicContent/dynamicContent.blocks';
 import ContentService from './content.service';
 import ButtonBlock from './buttonBlock';
+import PreferenceCenterBlocks from './preferenceCenter/preferenceCenter.blocks';
 export default ((editor, opts = {}) => {
   const bm = editor.BlockManager;
   const cfg = editor.getConfig();
@@ -10,14 +11,21 @@ export default ((editor, opts = {}) => {
   } else if ('grapesjsnewsletter' in cfg.pluginsOpts) {
     const dcb = new DynamicContentBlocks(editor, opts);
     dcb.addDynamciContentBlock();
-  } //add button block for landing page
-
+  }
 
   const mode = ContentService.getMode(editor);
 
   if (mode === ContentService.modePageHtml) {
+    //add button block for landing page
     const buttonBlock = new ButtonBlock(editor);
-    buttonBlock.addButtonBlock();
+    buttonBlock.addButtonBlock(); //check if page is for preference center 
+
+    const isPreferenceCenter = ContentService.isPreferenceCenter();
+
+    if (isPreferenceCenter) {
+      const pcb = new PreferenceCenterBlocks(editor);
+      pcb.addPreferenceCenterBlock();
+    }
   } // Add icon to mj-hero
 
 
@@ -41,9 +49,58 @@ export default ((editor, opts = {}) => {
     });
   });
   /*
+   * Blocks for Preference Center Category
+   */
+  //check if page is for preference center
+
+  if (mQuery('#page_isPreferenceCenter_1').is(':checked')) {
+    if (typeof bm.get('MyCategories') !== 'undefined') {
+      bm.get('MyCategories').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel')
+      });
+    }
+
+    if (typeof bm.get('MySegment') !== 'undefined') {
+      bm.get('MySegment').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel')
+      });
+    }
+
+    if (typeof bm.get('PreferredChannel') !== 'undefined') {
+      bm.get('PreferredChannel').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel')
+      });
+    }
+
+    if (typeof bm.get('SuccessMessage') !== 'undefined') {
+      bm.get('SuccessMessage').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel')
+      });
+    }
+
+    if (typeof bm.get('ChannelFrequency') !== 'undefined') {
+      bm.get('ChannelFrequency').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel')
+      });
+    }
+
+    if (typeof bm.get('SavePreferences') !== 'undefined') {
+      bm.get('SavePreferences').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel')
+      });
+    }
+
+    if (typeof bm.get('UnsubscribeAll') !== 'undefined') {
+      bm.get('UnsubscribeAll').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel')
+      });
+    }
+  }
+  /*
    * Custom block inside Sections category
    */
   // MJML columns
+
 
   if (typeof bm.get('mj-1-column') !== 'undefined') {
     bm.get('mj-1-column').set({

--- a/dist/components.js
+++ b/dist/components.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-else-return */
 import DynamicContentDomComponents from './dynamicContent/dynamicContent.domcomponents';
+import PreferenceCenterDomComponents from './preferenceCenter/preferenceCenter.domcomponents';
 import ContentService from './content.service'; // https://grapesjs.com/docs/api/component.html
 
 export default (editor => {
@@ -8,4 +9,49 @@ export default (editor => {
   if (mode === ContentService.modeEmailHtml) {
     DynamicContentDomComponents.addDynamicContentType(editor);
   }
+
+  if (mode === ContentService.modePageHtml) {
+    const pcdc = new PreferenceCenterDomComponents(editor);
+    pcdc.addPreferenceCenterType();
+  }
+
+  editor.DomComponents.addType('input', {
+    isComponent: el => el.tagName == 'INPUT',
+    model: {
+      defaults: {
+        traits: [// Strings are automatically converted to text types
+        'name', // Same as: { type: 'text', name: 'name' }
+        'placeholder', {
+          type: 'select',
+          // Type of the trait
+          label: 'Type',
+          // The label you will see in Settings
+          name: 'type',
+          // The name of the attribute/property to use on component
+          options: [{
+            id: 'text',
+            name: 'Text'
+          }, {
+            id: 'email',
+            name: 'Email'
+          }, {
+            id: 'password',
+            name: 'Password'
+          }, {
+            id: 'number',
+            name: 'Number'
+          }]
+        }, {
+          type: 'checkbox',
+          name: 'required'
+        }],
+        // As by default, traits are binded to attributes, so to define
+        // their initial value we can use attributes
+        attributes: {
+          type: 'text',
+          required: true
+        }
+      }
+    }
+  });
 });

--- a/dist/content.service.js
+++ b/dist/content.service.js
@@ -10,6 +10,10 @@ export default class ContentService {
     return ContentService.getMode(editor) === ContentService.modeEmailMjml;
   }
 
+  static isPreferenceCenter() {
+    return mQuery('#page_isPreferenceCenter_1').is(':checked');
+  }
+
   static getMode(editor) {
     const cfg = editor.getConfig();
 

--- a/dist/preferenceCenter/preferenceCenter.blocks.js
+++ b/dist/preferenceCenter/preferenceCenter.blocks.js
@@ -1,0 +1,203 @@
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+export default class PreferenceCenterBlocks {
+  constructor(editor) {
+    _defineProperty(this, "blockManager", void 0);
+
+    this.blockManager = editor.BlockManager;
+  }
+
+  addPreferenceCenterBlock() {
+    this.blockManager.add('MyCategories', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.myCategories.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      attributes: {
+        class: 'fa fa-bookmark-o'
+      },
+      content: `<div data-slot="categorylist">
+          <div draggable="false">
+            <div draggable="false">
+              <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.myCategories.label')}</label>
+            </div>
+            <div draggable="false">
+              <input
+                type="checkbox"
+                autocomplete="false"
+                value="1"
+                checked="checked"
+                draggable="false"
+              />
+              <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.myCategories.text')}</label>
+            </div>
+          </div>
+        </div>`,
+      style: {
+        padding: '50px'
+      }
+    });
+    this.blockManager.add('MySegment', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.mySegments.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-list-alt'
+      },
+      content: `<div data-slot="segmentlist">
+          <div draggable="false">
+            <div draggable="false">
+              <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.mySegments.label')}</label>
+            </div>
+            <div draggable="false">
+              <input
+                type="checkbox"
+                autocomplete="false"
+                value="2"
+                checked="checked"
+                draggable="false"
+              />
+              <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.mySegments.label')}</label>
+            </div>
+          </div>
+        </div>`,
+      style: {
+        padding: '50px'
+      }
+    });
+    this.blockManager.add('PreferredChannel', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.preferredChannel.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-envelope-o'
+      },
+      content: `<div data-slot="preferedchannel">
+          <div draggable="false">
+            <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.preferredChannel.label')}</label>
+            <div draggable="false">
+              <select draggable="false">
+                <option value="${Mautic.translate('grapesjsbuilder.email')}" selected="selected">${Mautic.translate('grapesjsbuilder.email')}</option>
+              </select>
+            </div>
+          </div>
+        </div>`,
+      style: {
+        padding: '50px'
+      }
+    });
+    this.blockManager.add('SuccessMessage', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.successMessage.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-check'
+      },
+      content: `
+        <div data-slot="successmessage">
+            <span draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.successMessage.label')}</span>
+        </div>`,
+      style: {
+        padding: '50px'
+      }
+    });
+    this.blockManager.add('ChannelFrequency', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-calendar'
+      },
+      content: `<div data-slot="channelfrequency">
+          <table class="table table-striped" draggable="false">
+            <tbody>
+              <tr draggable="false">
+                <td draggable="false">
+                  <div class="text-left" draggable="false">
+                    <input type="checkbox" checked="" draggable="false">
+                    <label class="control-label" draggable="false">
+                        ${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.contact_through')}
+                    </label>
+                  </div>
+                </td>
+              </tr>
+              <tr draggable="false">
+                <td draggable="false">
+                  <div id="frequency_email" class="text-left row" draggable="false">
+                    <div draggable="false">
+                      <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.do_not_send')}</label>
+                      <input type="text" class="frequency form-control" draggable="false">
+                      <label class="fw-n frequency-label" draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.each')}</label>
+                      <select class="form-control" draggable="false">
+                        <option value="" selected="selected" draggable="false"></option>
+                      </select>
+                    </div>
+                    <div draggable="false">
+                      <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.pause_from')}</label>
+                      <input type="date" class="form-control" draggable="false">
+                      <label class="frequency-label fw-n" draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.to')}</label>
+                      <input type="date" class="form-control" draggable="false">
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>`,
+      style: {
+        padding: '50px'
+      }
+    });
+    this.blockManager.add('UnsubscribeAll', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.unsubscribeAll.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-ban'
+      },
+      content: `<div data-slot="donotcontact">
+            <a href="{dnc_url}" draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.unsubscribeAll.link')}</a> 
+            <span draggable="false"> ${Mautic.translate('grapesjsbuilder.preferenceCenter.block.unsubscribeAll.text')}</span>
+        </div>`,
+      style: {
+        padding: '50px'
+      }
+    });
+    const style = `<style>
+            .button {
+              display:inline-block;
+              text-decoration:none;
+              border-color:#4e5d9d;
+              border-width:10px 20px;
+              border-style:solid;
+              -webkit-border-radius:3px;
+              -moz-border-radius:3px;
+              border-radius:3px;
+              background-color:#4e5d9d;
+              font-size:16px;
+              color:#ffffff;
+            }           
+          </style>`;
+    this.blockManager.add('SavePreferences', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.savePreferences.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      attributes: {
+        class: 'gjs-fonts gjs-f-button'
+      },
+      content: `
+        ${style}
+        <div data-slot="saveprefsbutton">
+          <a class="button btn btn-default btn-save" draggable="false">
+            ${Mautic.translate('grapesjsbuilder.preferenceCenter.block.savePreferences.link')}
+          </a>
+          <div style="clear: both"></div>
+        </div>`
+    });
+  }
+
+}

--- a/dist/preferenceCenter/preferenceCenter.domcomponents.js
+++ b/dist/preferenceCenter/preferenceCenter.domcomponents.js
@@ -1,0 +1,226 @@
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+export default class PreferenceCenterDomComponents {
+  constructor(editor) {
+    _defineProperty(this, "editor", void 0);
+
+    this.editor = editor;
+  }
+
+  addPreferenceCenterType() {
+    const idTrait = {
+      name: 'id'
+    };
+    const nameTrait = {
+      name: 'name'
+    };
+    const valueTrait = {
+      name: 'value'
+    };
+    const requiredTrait = {
+      type: 'checkbox',
+      name: 'required'
+    };
+    const checkedTrait = {
+      type: 'checkbox',
+      name: 'checked'
+    };
+    const dc = this.editor.DomComponents;
+    dc.addType('input', {
+      isComponent: function (e) {
+        return 'INPUT' == e.tagName;
+      },
+      model: {
+        defaults: {
+          tagName: 'input',
+          attributes: {
+            type: 'text'
+          }
+        }
+      },
+      extendFnView: ['updateAttributes'],
+      view: {
+        updateAttributes: function () {
+          this.el.setAttribute('autocomplete', 'off');
+        }
+      }
+    }), dc.addType('checkbox', {
+      extend: 'input',
+      isComponent: function (e) {
+        return 'INPUT' == e.tagName && 'checkbox' == e.type;
+      },
+      model: {
+        defaults: {
+          copyable: !1,
+          attributes: {
+            type: 'checkbox'
+          },
+          traits: [idTrait, nameTrait, valueTrait, requiredTrait, checkedTrait]
+        }
+      },
+      view: {
+        events: {
+          click: function (e) {
+            return e.preventDefault();
+          }
+        },
+        init: function () {
+          this.listenTo(this.model, 'change:attributes:checked', this.handleChecked);
+        },
+        handleChecked: function () {
+          this.el.checked = !!this.model.get('attributes').checked;
+        }
+      }
+    }), dc.addType('label', {
+      extend: 'text',
+      isComponent: function (e) {
+        return 'LABEL' == e.tagName;
+      },
+      model: {
+        defaults: {
+          tagName: 'label',
+          components: 'Label'
+        }
+      }
+    });
+    dc.addType('option', {
+      isComponent: el => el.tagName == 'OPTION',
+      model: {
+        defaults: {
+          tagName: 'option',
+          layerable: false,
+          droppable: false,
+          draggable: false,
+          highlightable: false
+        }
+      }
+    });
+
+    const createOption = (value, name) => ({
+      type: 'option',
+      components: name,
+      attributes: {
+        value
+      }
+    });
+
+    dc.addType('select', {
+      extend: 'input',
+      isComponent: el => el.tagName == 'SELECT',
+      model: {
+        defaults: {
+          tagName: 'select',
+          components: [createOption('email', 'Email') //createOption('opt2', 'Option 2'),
+          ],
+          traits: [nameTrait, {
+            name: 'options',
+            type: 'select-options'
+          }, requiredTrait]
+        }
+      },
+      view: {
+        events: {
+          mousedown: e => e.preventDefault()
+        }
+      }
+    });
+    const domc = this.editor.DomComponents;
+    const defaultType = domc.getType('default');
+    const defaultModel = defaultType.model;
+    const defaultView = defaultType.view;
+    dc.addType('date', {
+      model: defaultModel.extend({
+        defaults: { ...defaultModel.prototype.defaults,
+          'custom-name': 'date',
+          tagName: 'input',
+          type: 'date',
+          attributes: {
+            'data-gjs-type': 'date',
+            'data-slot': 'date'
+          },
+          droppable: false,
+          // Can't drop other elements inside
+          copyable: false,
+          // Do not allow to duplicate the component
+          script: function () {
+            var input = this;
+
+            var initDateRange = function () {
+              var input = this;
+              const options = {
+                singleDatePicker: true,
+                showDropdowns: true
+              };
+              $(input).daterangepicker(options);
+            };
+
+            if (typeof daterangepicker == 'undefined' || typeof jQuery == 'undefined' || typeof moment == 'undefined') {
+              if (typeof jQuery == 'undefined') {
+                var jquery = document.createElement('script');
+                jquery.src = '//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js';
+                document.body.appendChild(jquery);
+
+                jquery.onload = function () {
+                  loadMoment();
+                };
+              } else {
+                loadMoment();
+              }
+
+              function loadMoment() {
+                if (typeof moment == 'undefined') {
+                  var moment = document.createElement('script');
+                  moment.src = '//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js';
+                  document.body.appendChild(moment);
+
+                  moment.onload = function () {
+                    loadDatePicker();
+                  };
+                } else {
+                  loadDatePicker();
+                }
+              }
+
+              function loadDatePicker() {
+                if (typeof $ == 'undefined') {
+                  window.$ = jQuery;
+                }
+
+                var link = document.createElement('link');
+                link.rel = 'stylesheet';
+                link.href = '//cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.5/daterangepicker.min.css';
+                document.body.appendChild(link);
+                var daterangepicker = document.createElement('script');
+                daterangepicker.src = '//cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.5/daterangepicker.min.js';
+                document.body.appendChild(daterangepicker);
+                daterangepicker.onload = initDateRange;
+              }
+            } else {
+              // console.log("all libs present");
+              initDateRange();
+            }
+          }
+        }
+      }, {
+        isComponent(el) {
+          var dateType;
+
+          if (el.getAttribute && el.getAttribute('data-slot') === 'date') {
+            dateType = true;
+          } else {
+            dateType = false;
+          }
+
+          if (el.tagName == 'INPUT' && dateType) {
+            return {
+              type: 'date'
+            };
+          }
+        }
+
+      }),
+      view: defaultView
+    });
+  }
+
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "grapesjs-preset-mautic",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -2915,14 +2916,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001344",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/caseless": {
       "version": "0.12.0",
@@ -14282,9 +14289,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001251",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz",
-      "integrity": "sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==",
+      "version": "1.0.30001344",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001344.tgz",
+      "integrity": "sha512-0ZFjnlCaXNOAYcV7i+TtdKBp0L/3XEU2MF/x6Du1lrh+SRX4IfzIVL4HNJg5pB2PmFb8rszIGyOvsZnqqRoc2g==",
       "dev": true
     },
     "caseless": {

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1,21 +1,33 @@
 import DynamicContentBlocks from './dynamicContent/dynamicContent.blocks';
 import ContentService from './content.service';
 import ButtonBlock from './buttonBlock';
+import PreferenceCenterBlocks from './preferenceCenter/preferenceCenter.blocks';
 
 export default (editor, opts = {}) => {
   const bm = editor.BlockManager;
+  const cfg = editor.getConfig();
   const blocks = bm.getAll();
 
-  const mode = ContentService.getMode(editor);
-
-  // a add button block for landing page
-  if (mode === ContentService.modePageHtml) {
-    const buttonBlock = new ButtonBlock(editor);
-    buttonBlock.addButtonBlock();
-  } else {
-    // Add Dynamic Content block only for email modes
+  // Add Dynamic Content block only for newsletter
+  if ('grapesjsmjml' in cfg.pluginsOpts) {
+    // Dynamic Content MJML block
+  } else if ('grapesjsnewsletter' in cfg.pluginsOpts) {
     const dcb = new DynamicContentBlocks(editor, opts);
     dcb.addDynamciContentBlock();
+  }
+
+  const mode = ContentService.getMode(editor);
+  if (mode === ContentService.modePageHtml) {
+    //add button block for landing page
+    const buttonBlock = new ButtonBlock(editor);
+    buttonBlock.addButtonBlock();
+
+    //check if page is for preference center 
+    const isPreferenceCenter = ContentService.isPreferenceCenter();
+    if(isPreferenceCenter) { 
+      const pcb = new PreferenceCenterBlocks(editor);
+      pcb.addPreferenceCenterBlock();
+    }
   }
 
   // Add icon to mj-hero
@@ -36,6 +48,54 @@ export default (editor, opts = {}) => {
       category: Mautic.translate('grapesjsbuilder.categoryBlockLabel'),
     });
   });
+
+  /*
+   * Blocks for Preference Center Category
+   */
+  //check if page is for preference center
+  if (mQuery('#page_isPreferenceCenter_1').is(':checked')) {
+    if (typeof bm.get('MyCategories') !== 'undefined') {
+      bm.get('MyCategories').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      });
+    }
+
+    if (typeof bm.get('MySegment') !== 'undefined') {
+      bm.get('MySegment').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      });
+    }
+
+    if (typeof bm.get('PreferredChannel') !== 'undefined') {
+      bm.get('PreferredChannel').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      });
+    }
+
+    if (typeof bm.get('SuccessMessage') !== 'undefined') {
+      bm.get('SuccessMessage').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      });
+    }
+
+    if (typeof bm.get('ChannelFrequency') !== 'undefined') {
+      bm.get('ChannelFrequency').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      });
+    }
+
+    if (typeof bm.get('SavePreferences') !== 'undefined') {
+      bm.get('SavePreferences').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      });
+    }
+
+    if (typeof bm.get('UnsubscribeAll') !== 'undefined') {
+      bm.get('UnsubscribeAll').set({
+        category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      });
+    }
+  }
 
   /*
    * Custom block inside Sections category

--- a/src/components.js
+++ b/src/components.js
@@ -1,7 +1,46 @@
 /* eslint-disable no-else-return */
 import DynamicContentDomComponents from './dynamicContent/dynamicContent.domcomponents';
+import PreferenceCenterDomComponents from './preferenceCenter/preferenceCenter.domcomponents';
+import ContentService from './content.service';
 
 // https://grapesjs.com/docs/api/component.html
 export default (editor) => {
-  DynamicContentDomComponents.addDynamicContentType(editor);
+  const mode = ContentService.getMode(editor);
+  if (mode === ContentService.modeEmailHtml) {
+    DynamicContentDomComponents.addDynamicContentType(editor);
+  }
+ 
+  if(mode === ContentService.modePageHtml){
+    const pcdc = new PreferenceCenterDomComponents(editor);
+    pcdc.addPreferenceCenterType();
+  }
+
+  editor.DomComponents.addType('input', {
+    isComponent: el => el.tagName == 'INPUT',
+    model: {
+      defaults: {
+        traits: [
+          // Strings are automatically converted to text types
+          'name', // Same as: { type: 'text', name: 'name' }
+          'placeholder',
+          {
+            type: 'select', // Type of the trait
+            label: 'Type', // The label you will see in Settings
+            name: 'type', // The name of the attribute/property to use on component
+            options: [
+              { id: 'text', name: 'Text'},
+              { id: 'email', name: 'Email'},
+              { id: 'password', name: 'Password'},
+              { id: 'number', name: 'Number'},
+            ]
+          }, {
+            type: 'checkbox',
+            name: 'required',
+          }],
+        // As by default, traits are binded to attributes, so to define
+        // their initial value we can use attributes
+        attributes: { type: 'text', required: true },
+      },
+    },
+  });
 };

--- a/src/content.service.js
+++ b/src/content.service.js
@@ -14,6 +14,10 @@ export default class ContentService {
     return ContentService.getMode(editor) === ContentService.modeEmailMjml;
   }
 
+  static isPreferenceCenter(){
+    return mQuery('#page_isPreferenceCenter_1').is(':checked');
+  }
+
   static getMode(editor) {
     const cfg = editor.getConfig();
 

--- a/src/dynamicContent/dynamicContent.blocks.js
+++ b/src/dynamicContent/dynamicContent.blocks.js
@@ -25,4 +25,6 @@ export default class DynamicContentBlocks {
       },
     });
   }
+
+  
 }

--- a/src/dynamicContent/dynamicContent.commands.js
+++ b/src/dynamicContent/dynamicContent.commands.js
@@ -1,5 +1,4 @@
 import Logger from '../logger';
-import MjmlService from '../mjml/mjml.service';
 import DynamicContentService from './dynamicContent.service';
 
 export default class DynamicContentCommands {
@@ -54,8 +53,6 @@ export default class DynamicContentCommands {
   convertDynamicContentComponentsToTokens(editor) {
     // get all dynamic content elements loaded in the editor
     const dynamicContents = editor.DomComponents.getWrapper().find('[data-slot="dynamicContent"]');
-    this.logger.debug(`DC: ${dynamicContents.length} components found`, { dynamicContents });
-
     dynamicContents.forEach((dynamicContent) => {
       const attributes = dynamicContent.getAttributes();
       const decId = attributes['data-param-dec-id'];

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -1,4 +1,3 @@
-import ContentService from '../content.service';
 import DynamicContentService from './dynamicContent.service';
 
 export default class DynamicContentDomComponents {
@@ -6,24 +5,23 @@ export default class DynamicContentDomComponents {
 
   static addDynamicContentType(editor) {
     const dc = editor.DomComponents;
-    const baseTypeName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'text';
-    const tagName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'div';
-    const baseType = dc.getType(baseTypeName);
-    const baseModel = baseType.model;
-    const model = baseModel.extend(
+    const defaultType = dc.getType('default');
+    const defaultModel = defaultType.model;
+
+    const model = defaultModel.extend(
       {
         defaults: {
-          ...baseModel.prototype.defaults,
+          ...defaultModel.prototype.defaults,
           name: 'Dynamic Content',
-          tagName,
-          draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
+          draggable: '[data-gjs-type=cell]',
           droppable: false,
           editable: false,
           stylable: false,
           propagate: ['droppable', 'editable'],
           attributes: {
+            // Default attributes
             'data-gjs-type': 'dynamic-content', // Type for GrapesJS
-            'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation
+            'data-slot': 'dynamicContent', // Retro compatibility with old template
           },
         },
         /**
@@ -69,7 +67,7 @@ export default class DynamicContentDomComponents {
       }
     );
 
-    const view = baseType.view.extend({
+    const view = defaultType.view.extend({
       attributes: {
         style: 'pointer-events: all; display: table; width: 100%;user-select: none;',
       },

--- a/src/mjml/mjml.service.js
+++ b/src/mjml/mjml.service.js
@@ -52,8 +52,6 @@ export default class MjmlService {
         throw new Error('No valid MJML provided');
       }
       // html needs to be beautified for the click tracking to work.
-      // strict mode not working with e.g. id="" and data-type parameters that
-      // are e.g. used for Dynamic Content
       return mjml2html(mjml, { beautify: true });
     } catch (error) {
       console.warn(error);

--- a/src/preferenceCenter/preferenceCenter.blocks.js
+++ b/src/preferenceCenter/preferenceCenter.blocks.js
@@ -1,0 +1,199 @@
+export default class PreferenceCenterBlocks {
+  blockManager;
+
+  constructor(editor) {
+    this.blockManager = editor.BlockManager;
+  }
+
+  addPreferenceCenterBlock() {
+    this.blockManager.add('MyCategories', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.myCategories.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      attributes: {
+        class: 'fa fa-bookmark-o',
+      },
+      content:
+        `<div data-slot="categorylist">
+          <div draggable="false">
+            <div draggable="false">
+              <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.myCategories.label')}</label>
+            </div>
+            <div draggable="false">
+              <input
+                type="checkbox"
+                autocomplete="false"
+                value="1"
+                checked="checked"
+                draggable="false"
+              />
+              <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.myCategories.text')}</label>
+            </div>
+          </div>
+        </div>`,
+      style: { padding: '50px' },
+    });
+
+    this.blockManager.add('MySegment', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.mySegments.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-list-alt'
+      },
+      content:
+        `<div data-slot="segmentlist">
+          <div draggable="false">
+            <div draggable="false">
+              <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.mySegments.label')}</label>
+            </div>
+            <div draggable="false">
+              <input
+                type="checkbox"
+                autocomplete="false"
+                value="2"
+                checked="checked"
+                draggable="false"
+              />
+              <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.mySegments.label')}</label>
+            </div>
+          </div>
+        </div>`,
+      style: { padding: '50px' },
+    });
+
+    this.blockManager.add('PreferredChannel', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.preferredChannel.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-envelope-o'
+      },
+      content:
+        `<div data-slot="preferedchannel">
+          <div draggable="false">
+            <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.preferredChannel.label')}</label>
+            <div draggable="false">
+              <select draggable="false">
+                <option value="${Mautic.translate('grapesjsbuilder.email')}" selected="selected">${Mautic.translate('grapesjsbuilder.email')}</option>
+              </select>
+            </div>
+          </div>
+        </div>`,
+      style: { padding: '50px' },
+    });
+
+    this.blockManager.add('SuccessMessage', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.successMessage.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-check'
+      },
+      content: `
+        <div data-slot="successmessage">
+            <span draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.successMessage.label')}</span>
+        </div>`,
+      style: { padding: '50px' },
+    });
+
+    this.blockManager.add('ChannelFrequency', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-calendar'
+      },
+      content:
+        `<div data-slot="channelfrequency">
+          <table class="table table-striped" draggable="false">
+            <tbody>
+              <tr draggable="false">
+                <td draggable="false">
+                  <div class="text-left" draggable="false">
+                    <input type="checkbox" checked="" draggable="false">
+                    <label class="control-label" draggable="false">
+                        ${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.contact_through')}
+                    </label>
+                  </div>
+                </td>
+              </tr>
+              <tr draggable="false">
+                <td draggable="false">
+                  <div id="frequency_email" class="text-left row" draggable="false">
+                    <div draggable="false">
+                      <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.do_not_send')}</label>
+                      <input type="text" class="frequency form-control" draggable="false">
+                      <label class="fw-n frequency-label" draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.each')}</label>
+                      <select class="form-control" draggable="false">
+                        <option value="" selected="selected" draggable="false"></option>
+                      </select>
+                    </div>
+                    <div draggable="false">
+                      <label draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.pause_from')}</label>
+                      <input type="date" class="form-control" draggable="false">
+                      <label class="frequency-label fw-n" draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.channelFrequency.text.to')}</label>
+                      <input type="date" class="form-control" draggable="false">
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>`,
+      style: { padding: '50px' },
+    });
+
+    this.blockManager.add('UnsubscribeAll', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.unsubscribeAll.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      draggable: false,
+      attributes: {
+        class: 'fa fa-ban'
+      },
+      content:
+        `<div data-slot="donotcontact">
+            <a href="{dnc_url}" draggable="false">${Mautic.translate('grapesjsbuilder.preferenceCenter.block.unsubscribeAll.link')}</a> 
+            <span draggable="false"> ${Mautic.translate('grapesjsbuilder.preferenceCenter.block.unsubscribeAll.text')}</span>
+        </div>`,
+      style: { padding: '50px' },
+    });
+
+    const style = `<style>
+            .button {
+              display:inline-block;
+              text-decoration:none;
+              border-color:#4e5d9d;
+              border-width:10px 20px;
+              border-style:solid;
+              -webkit-border-radius:3px;
+              -moz-border-radius:3px;
+              border-radius:3px;
+              background-color:#4e5d9d;
+              font-size:16px;
+              color:#ffffff;
+            }           
+          </style>`;
+    this.blockManager.add('SavePreferences', {
+      tagName: 'div',
+      label: Mautic.translate('grapesjsbuilder.preferenceCenter.block.savePreferences.label'),
+      category: Mautic.translate('grapesjsbuilder.preferenceCenterLabel'),
+      attributes: {
+        class: 'gjs-fonts gjs-f-button',
+      },
+      content: `
+        ${style}
+        <div data-slot="saveprefsbutton">
+          <a class="button btn btn-default btn-save" draggable="false">
+            ${Mautic.translate('grapesjsbuilder.preferenceCenter.block.savePreferences.link')}
+          </a>
+          <div style="clear: both"></div>
+        </div>`
+    });
+  }
+}

--- a/src/preferenceCenter/preferenceCenter.domcomponents.js
+++ b/src/preferenceCenter/preferenceCenter.domcomponents.js
@@ -1,0 +1,228 @@
+export default class PreferenceCenterDomComponents {
+  editor;
+
+  constructor(editor) {
+    this.editor = editor;
+  }
+
+  addPreferenceCenterType() {
+    const idTrait = {
+      name: 'id',
+    };
+    const nameTrait = {
+      name: 'name',
+    };
+    const valueTrait = {
+      name: 'value',
+    };
+
+    const requiredTrait = {
+      type: 'checkbox',
+      name: 'required',
+    };
+
+    const checkedTrait = {
+      type: 'checkbox',
+      name: 'checked',
+    };
+    const dc = this.editor.DomComponents;
+    dc.addType('input', {
+      isComponent: function (e) {
+        return 'INPUT' == e.tagName;
+      },
+      model: {
+        defaults: {
+          tagName: 'input',
+          attributes: { type: 'text' },
+        },
+      },
+      extendFnView: ['updateAttributes'],
+      view: {
+        updateAttributes: function () {
+          this.el.setAttribute('autocomplete', 'off');
+        },
+      },
+    }),
+      dc.addType('checkbox', {
+        extend: 'input',
+        isComponent: function (e) {
+          return 'INPUT' == e.tagName && 'checkbox' == e.type;
+        },
+        model: {
+          defaults: {
+            copyable: !1,
+            attributes: { type: 'checkbox' },
+            traits: [idTrait, nameTrait, valueTrait, requiredTrait, checkedTrait],
+          },
+        },
+        view: {
+          events: {
+            click: function (e) {
+              return e.preventDefault();
+            },
+          },
+          init: function () {
+            this.listenTo(this.model, 'change:attributes:checked', this.handleChecked);
+          },
+          handleChecked: function () {
+            this.el.checked = !!this.model.get('attributes').checked;
+          },
+        },
+      }),
+      dc.addType('label', {
+        extend: 'text',
+        isComponent: function (e) {
+          return 'LABEL' == e.tagName;
+        },
+        model: { defaults: { tagName: 'label', components: 'Label' } },
+      });
+    dc.addType('option', {
+      isComponent: (el) => el.tagName == 'OPTION',
+
+      model: {
+        defaults: {
+          tagName: 'option',
+          layerable: false,
+          droppable: false,
+          draggable: false,
+          highlightable: false,
+        },
+      },
+    });
+
+    const createOption = (value, name) => ({
+      type: 'option',
+      components: name,
+      attributes: { value },
+    });
+
+    dc.addType('select', {
+      extend: 'input',
+      isComponent: (el) => el.tagName == 'SELECT',
+
+      model: {
+        defaults: {
+          tagName: 'select',
+          components: [
+            createOption('email', 'Email'),
+            //createOption('opt2', 'Option 2'),
+          ],
+          traits: [
+            nameTrait,
+            {
+              name: 'options',
+              type: 'select-options',
+            },
+            requiredTrait,
+          ],
+        },
+      },
+
+      view: {
+        events: {
+          mousedown: (e) => e.preventDefault(),
+        },
+      },
+    });
+
+    const domc = this.editor.DomComponents;
+    const defaultType = domc.getType('default');
+    const defaultModel = defaultType.model;
+    const defaultView = defaultType.view;
+
+    dc.addType('date', {
+      model: defaultModel.extend(
+        {
+          defaults: {
+            ...defaultModel.prototype.defaults,
+            'custom-name': 'date',
+            tagName: 'input',
+            type: 'date',
+            attributes: {
+              'data-gjs-type': 'date',
+              'data-slot': 'date',
+            },
+            droppable: false, // Can't drop other elements inside
+            copyable: false, // Do not allow to duplicate the component
+            script: function () {
+              var input = this;
+              var initDateRange = function () {
+                var input = this;
+                const options = {
+                  singleDatePicker: true,
+                  showDropdowns: true,
+                };
+                $(input).daterangepicker(options);
+              };
+
+              if (
+                typeof daterangepicker == 'undefined' ||
+                typeof jQuery == 'undefined' ||
+                typeof moment == 'undefined'
+              ) {
+                if (typeof jQuery == 'undefined') {
+                  var jquery = document.createElement('script');
+                  jquery.src = '//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js';
+                  document.body.appendChild(jquery);
+
+                  jquery.onload = function () {
+                    loadMoment();
+                  };
+                } else {
+                  loadMoment();
+                }
+                function loadMoment() {
+                  if (typeof moment == 'undefined') {
+                    var moment = document.createElement('script');
+                    moment.src = '//cdnjs.cloudflare.com/ajax/libs/moment.js/2.24.0/moment.min.js';
+                    document.body.appendChild(moment);
+
+                    moment.onload = function () {
+                      loadDatePicker();
+                    };
+                  } else {
+                    loadDatePicker();
+                  }
+                }
+                function loadDatePicker() {
+                  if (typeof $ == 'undefined') {
+                    window.$ = jQuery;
+                  }
+                  var link = document.createElement('link');
+                  link.rel = 'stylesheet';
+                  link.href =
+                    '//cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.5/daterangepicker.min.css';
+                  document.body.appendChild(link);
+
+                  var daterangepicker = document.createElement('script');
+                  daterangepicker.src =
+                    '//cdnjs.cloudflare.com/ajax/libs/bootstrap-daterangepicker/3.0.5/daterangepicker.min.js';
+                  document.body.appendChild(daterangepicker);
+
+                  daterangepicker.onload = initDateRange;
+                }
+              } else {
+                // console.log("all libs present");
+                initDateRange();
+              }
+            },
+          },
+        },
+        {
+          isComponent(el) {
+            var dateType;
+            if (el.getAttribute && el.getAttribute('data-slot') === 'date') {
+              dateType = true;
+            } else {
+              dateType = false;
+            }
+            if (el.tagName == 'INPUT' && dateType) {
+              return { type: 'date' };
+            }
+          },
+        }
+      ),
+      view: defaultView,
+    });
+  }
+}


### PR DESCRIPTION
Preference center finished based on https://github.com/mautic/grapesjs-preset-mautic/pull/8.

A few notes : 
- The solution I used here is not optimal (the use of HTML strings to define block contents) but is necessary to ensure that elements are not draggable and thus to prevent user errors (when using the component approach, draggable attributes would reset after closing/re-opening the builder).
- Translations strings are set up, but I don't know how to include them here ? (I put them in the GrapesJsBuilderBundle for my tests)
- I have changed icons definition to use fontawesome.
