### PR TITLE
feat: [DPMMA-2044] Loading custom fonts into GrapesJS editor

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
     // "grapesjs": true,
     "Mousetrap": true,
     "Mautic": true,
-    "mauticAjaxCsrf": true
+    "mauticAjaxCsrf": true,
+    "mauticEditorFonts": true
   }
 }

--- a/dist/buttons/buttonClose.command.js
+++ b/dist/buttons/buttonClose.command.js
@@ -9,7 +9,7 @@ export default class ButtonCloseCommands {
 
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
     const htmlDocument = ContentService.getCanvasAsHtmlDocument(editor);
-    let htmlString = ContentService.serializeHtmlDocument(htmlDocument); // eslint-disable-next-line no-undef
+    let htmlString = ContentService.serializeHtmlDocument(htmlDocument);
 
     if (mauticEditorFonts) {
       htmlString = EditorFontsService.addFontLinksToHtml(htmlString);
@@ -27,7 +27,7 @@ export default class ButtonCloseCommands {
 
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens'); // Getting HTML with CSS inline (only available for "grapesjs-preset-newsletter"):
 
-    let html = ContentService.getEditorHtmlContent(editor); // eslint-disable-next-line no-undef
+    let html = ContentService.getEditorHtmlContent(editor);
 
     if (mauticEditorFonts) {
       html = EditorFontsService.addFontLinksToHtml(html);
@@ -49,8 +49,7 @@ export default class ButtonCloseCommands {
 
     if (!htmlCode || !mjmlCode) {
       throw new Error('Could not generate html from MJML');
-    } // eslint-disable-next-line no-undef
-
+    }
 
     if (mauticEditorFonts) {
       htmlCode = EditorFontsService.addFontLinksToHtml(htmlCode);

--- a/dist/buttons/buttonClose.command.js
+++ b/dist/buttons/buttonClose.command.js
@@ -1,5 +1,6 @@
 import ContentService from '../content.service';
 import MjmlService from '../mjml/mjml.service';
+import EditorFontsService from '../editorFonts/editorFonts.service';
 export default class ButtonCloseCommands {
   static closeEditorPageHtml(editor) {
     if (!editor) {
@@ -8,7 +9,13 @@ export default class ButtonCloseCommands {
 
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
     const htmlDocument = ContentService.getCanvasAsHtmlDocument(editor);
-    ButtonCloseCommands.returnContentToTextarea(editor, ContentService.serializeHtmlDocument(htmlDocument)); // Reset HTML
+    let htmlString = ContentService.serializeHtmlDocument(htmlDocument); // eslint-disable-next-line no-undef
+
+    if (mauticEditorFonts) {
+      htmlString = EditorFontsService.addFontLinksToHtml(htmlString);
+    }
+
+    ButtonCloseCommands.returnContentToTextarea(editor, htmlString); // Reset HTML
 
     ButtonCloseCommands.resetHtml(editor);
   }
@@ -20,7 +27,12 @@ export default class ButtonCloseCommands {
 
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens'); // Getting HTML with CSS inline (only available for "grapesjs-preset-newsletter"):
 
-    const html = ContentService.getEditorHtmlContent(editor);
+    let html = ContentService.getEditorHtmlContent(editor); // eslint-disable-next-line no-undef
+
+    if (mauticEditorFonts) {
+      html = EditorFontsService.addFontLinksToHtml(html);
+    }
+
     ButtonCloseCommands.returnContentToTextarea(editor, html); // Reset HTML
 
     ButtonCloseCommands.resetHtml(editor);
@@ -32,11 +44,16 @@ export default class ButtonCloseCommands {
     }
 
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
-    const htmlCode = MjmlService.getEditorHtmlContent(editor);
+    let htmlCode = MjmlService.getEditorHtmlContent(editor);
     const mjmlCode = MjmlService.getEditorMjmlContent(editor); // Update textarea for save
 
     if (!htmlCode || !mjmlCode) {
       throw new Error('Could not generate html from MJML');
+    } // eslint-disable-next-line no-undef
+
+
+    if (mauticEditorFonts) {
+      htmlCode = EditorFontsService.addFontLinksToHtml(htmlCode);
     }
 
     ButtonCloseCommands.returnContentToTextarea(editor, htmlCode, mjmlCode); // Reset HTML

--- a/dist/editorFonts/editorFonts.service.js
+++ b/dist/editorFonts/editorFonts.service.js
@@ -1,0 +1,80 @@
+import ContentService from '../content.service';
+export default class EditorFontsService {
+  static loadEditorFonts(editor) {
+    const styleManager = editor.StyleManager;
+
+    if (!styleManager) {
+      // eslint-disable-next-line no-console
+      console.error('No GrapesJS Style Manager found.');
+      return;
+    }
+
+    const fontProperty = styleManager.getProperty('typography', 'font-family');
+
+    if (!fontProperty) {
+      // eslint-disable-next-line no-console
+      console.error('No font properties found in the typography sector.');
+      return;
+    }
+
+    const fontList = fontProperty.get('list');
+    EditorFontsService.updateFontList(editor, fontList);
+    EditorFontsService.sortFontList(fontList);
+    fontProperty.set('list', fontList);
+    styleManager.render();
+  }
+
+  static updateFontList(editor, fontList) {
+    const canvasHead = editor.Canvas.getDocument().head; // eslint-disable-next-line no-undef
+
+    mauticEditorFonts.forEach(item => {
+      if (!fontList.find(element => element.name === item.name)) {
+        fontList.push({
+          value: item.font,
+          name: item.name
+        });
+
+        if (item.url && canvasHead) {
+          EditorFontsService.appendFontStyleLink(canvasHead, item.url);
+        }
+      }
+    });
+    return fontList;
+  }
+
+  static sortFontList(fontList) {
+    fontList.sort((a, b) => a.name < b.name ? -1 : 1);
+    return fontList;
+  }
+
+  static addFontLinksToHtml(htmlCode) {
+    const htmlDoc = new DOMParser().parseFromString(htmlCode, 'text/html');
+    const headElem = htmlDoc.head;
+    const headLinks = [...headElem.getElementsByTagName('link')]; // eslint-disable-next-line no-undef
+
+    mauticEditorFonts.forEach(item => {
+      // Check which fonts are used
+      if (item.url && htmlCode.indexOf(item.font) !== -1) {
+        // Link fonts style, if they are not already linked
+        if (!headLinks.find(link => link.href === item.url)) {
+          EditorFontsService.appendFontStyleLink(headElem, item.url);
+        }
+      }
+    });
+    return ContentService.serializeHtmlDocument(htmlDoc);
+  }
+
+  static appendFontStyleLink(head, url) {
+    const linkElem = EditorFontsService.createStylesheetLink(url);
+    return head.appendChild(linkElem);
+  }
+
+  static createStylesheetLink(url) {
+    const linkElem = document.createElement('link');
+    linkElem.rel = 'stylesheet';
+    linkElem.type = 'text/css';
+    linkElem.href = url;
+    return linkElem;
+  }
+
+}

--- a/dist/editorFonts/editorFonts.service.js
+++ b/dist/editorFonts/editorFonts.service.js
@@ -25,8 +25,7 @@ export default class EditorFontsService {
   }
 
   static updateFontList(editor, fontList) {
-    const canvasHead = editor.Canvas.getDocument().head; // eslint-disable-next-line no-undef
-
+    const canvasHead = editor.Canvas.getDocument().head;
     mauticEditorFonts.forEach(item => {
       if (!fontList.find(element => element.name === item.name)) {
         fontList.push({
@@ -50,8 +49,7 @@ export default class EditorFontsService {
   static addFontLinksToHtml(htmlCode) {
     const htmlDoc = new DOMParser().parseFromString(htmlCode, 'text/html');
     const headElem = htmlDoc.head;
-    const headLinks = [...headElem.getElementsByTagName('link')]; // eslint-disable-next-line no-undef
-
+    const headLinks = [...headElem.getElementsByTagName('link')];
     mauticEditorFonts.forEach(item => {
       // Check which fonts are used
       if (item.url && htmlCode.indexOf(item.font) !== -1) {

--- a/src/buttons/buttonClose.command.js
+++ b/src/buttons/buttonClose.command.js
@@ -12,7 +12,6 @@ export default class ButtonCloseCommands {
     const htmlDocument = ContentService.getCanvasAsHtmlDocument(editor);
     let htmlString = ContentService.serializeHtmlDocument(htmlDocument);
 
-    // eslint-disable-next-line no-undef
     if (mauticEditorFonts) {
       htmlString = EditorFontsService.addFontLinksToHtml(htmlString);
     }
@@ -30,7 +29,6 @@ export default class ButtonCloseCommands {
 
     let html = ContentService.getEditorHtmlContent(editor);
 
-    // eslint-disable-next-line no-undef
     if (mauticEditorFonts) {
       html = EditorFontsService.addFontLinksToHtml(html);
     }
@@ -52,7 +50,6 @@ export default class ButtonCloseCommands {
       throw new Error('Could not generate html from MJML');
     }
 
-    // eslint-disable-next-line no-undef
     if (mauticEditorFonts) {
       htmlCode = EditorFontsService.addFontLinksToHtml(htmlCode);
     }

--- a/src/buttons/buttonClose.command.js
+++ b/src/buttons/buttonClose.command.js
@@ -1,5 +1,6 @@
 import ContentService from '../content.service';
 import MjmlService from '../mjml/mjml.service';
+import EditorFontsService from '../editorFonts/editorFonts.service';
 
 export default class ButtonCloseCommands {
   static closeEditorPageHtml(editor) {
@@ -8,15 +9,15 @@ export default class ButtonCloseCommands {
     }
 
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
-
     const htmlDocument = ContentService.getCanvasAsHtmlDocument(editor);
+    let htmlString = ContentService.serializeHtmlDocument(htmlDocument);
 
-    ButtonCloseCommands.returnContentToTextarea(
-      editor,
-      ContentService.serializeHtmlDocument(htmlDocument)
-    );
+    // eslint-disable-next-line no-undef
+    if (mauticEditorFonts) {
+      htmlString = EditorFontsService.addFontLinksToHtml(htmlString);
+    }
 
-    // Reset HTML
+    ButtonCloseCommands.returnContentToTextarea(editor, htmlString); // Reset HTML
     ButtonCloseCommands.resetHtml(editor);
   }
 
@@ -25,14 +26,16 @@ export default class ButtonCloseCommands {
       throw new Error('No email-HTML editor');
     }
 
-    editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
+    editor.runCommand('preset-mautic:dynamic-content-components-to-tokens'); // Getting HTML with CSS inline (only available for "grapesjs-preset-newsletter"):
 
-    // Getting HTML with CSS inline (only available for "grapesjs-preset-newsletter"):
-    const html = ContentService.getEditorHtmlContent(editor);
+    let html = ContentService.getEditorHtmlContent(editor);
 
-    ButtonCloseCommands.returnContentToTextarea(editor, html);
+    // eslint-disable-next-line no-undef
+    if (mauticEditorFonts) {
+      html = EditorFontsService.addFontLinksToHtml(html);
+    }
 
-    // Reset HTML
+    ButtonCloseCommands.returnContentToTextarea(editor, html); // Reset HTML
     ButtonCloseCommands.resetHtml(editor);
   }
 
@@ -40,18 +43,21 @@ export default class ButtonCloseCommands {
     if (!editor) {
       throw new Error('No email-MJML editor');
     }
+
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
+    let htmlCode = MjmlService.getEditorHtmlContent(editor);
+    const mjmlCode = MjmlService.getEditorMjmlContent(editor); // Update textarea for save
 
-    const htmlCode = MjmlService.getEditorHtmlContent(editor);
-    const mjmlCode = MjmlService.getEditorMjmlContent(editor);
-
-    // Update textarea for save
     if (!htmlCode || !mjmlCode) {
       throw new Error('Could not generate html from MJML');
     }
-    ButtonCloseCommands.returnContentToTextarea(editor, htmlCode, mjmlCode);
 
-    // Reset HTML
+    // eslint-disable-next-line no-undef
+    if (mauticEditorFonts) {
+      htmlCode = EditorFontsService.addFontLinksToHtml(htmlCode);
+    }
+
+    ButtonCloseCommands.returnContentToTextarea(editor, htmlCode, mjmlCode); // Reset HTML
     ButtonCloseCommands.resetHtml(editor);
   }
 

--- a/src/editorFonts/editorFonts.service.js
+++ b/src/editorFonts/editorFonts.service.js
@@ -28,7 +28,6 @@ export default class EditorFontsService {
   static updateFontList(editor, fontList) {
     const canvasHead = editor.Canvas.getDocument().head;
 
-    // eslint-disable-next-line no-undef
     mauticEditorFonts.forEach((item) => {
       if (!fontList.find((element) => element.name === item.name)) {
         fontList.push({ value: item.font, name: item.name });
@@ -53,7 +52,6 @@ export default class EditorFontsService {
     const headElem = htmlDoc.head;
     const headLinks = [...headElem.getElementsByTagName('link')];
 
-    // eslint-disable-next-line no-undef
     mauticEditorFonts.forEach((item) => {
       // Check which fonts are used
       if (item.url && htmlCode.indexOf(item.font) !== -1) {

--- a/src/editorFonts/editorFonts.service.js
+++ b/src/editorFonts/editorFonts.service.js
@@ -1,0 +1,83 @@
+import ContentService from '../content.service';
+
+export default class EditorFontsService {
+  static loadEditorFonts(editor) {
+    const styleManager = editor.StyleManager;
+
+    if (!styleManager) {
+      // eslint-disable-next-line no-console
+      console.error('No GrapesJS Style Manager found.');
+      return;
+    }
+
+    const fontProperty = styleManager.getProperty('typography', 'font-family');
+    if (!fontProperty) {
+      // eslint-disable-next-line no-console
+      console.error('No font properties found in the typography sector.');
+      return;
+    }
+
+    const fontList = fontProperty.get('list');
+    EditorFontsService.updateFontList(editor, fontList);
+    EditorFontsService.sortFontList(fontList);
+
+    fontProperty.set('list', fontList);
+    styleManager.render();
+  }
+
+  static updateFontList(editor, fontList) {
+    const canvasHead = editor.Canvas.getDocument().head;
+
+    // eslint-disable-next-line no-undef
+    mauticEditorFonts.forEach((item) => {
+      if (!fontList.find((element) => element.name === item.name)) {
+        fontList.push({ value: item.font, name: item.name });
+
+        if (item.url && canvasHead) {
+          EditorFontsService.appendFontStyleLink(canvasHead, item.url);
+        }
+      }
+    });
+
+    return fontList;
+  }
+
+  static sortFontList(fontList) {
+    fontList.sort((a, b) => (a.name < b.name ? -1 : 1));
+
+    return fontList;
+  }
+
+  static addFontLinksToHtml(htmlCode) {
+    const htmlDoc = new DOMParser().parseFromString(htmlCode, 'text/html');
+    const headElem = htmlDoc.head;
+    const headLinks = [...headElem.getElementsByTagName('link')];
+
+    // eslint-disable-next-line no-undef
+    mauticEditorFonts.forEach((item) => {
+      // Check which fonts are used
+      if (item.url && htmlCode.indexOf(item.font) !== -1) {
+        // Link fonts style, if they are not already linked
+        if (!headLinks.find((link) => link.href === item.url)) {
+          EditorFontsService.appendFontStyleLink(headElem, item.url);
+        }
+      }
+    });
+
+    return ContentService.serializeHtmlDocument(htmlDoc);
+  }
+
+  static appendFontStyleLink(head, url) {
+    const linkElem = EditorFontsService.createStylesheetLink(url);
+    return head.appendChild(linkElem);
+  }
+
+  static createStylesheetLink(url) {
+    const linkElem = document.createElement('link');
+    linkElem.rel = 'stylesheet';
+    linkElem.type = 'text/css';
+    linkElem.href = url;
+
+    return linkElem;
+  }
+}


### PR DESCRIPTION
PR introduces the ability to load and use custom fonts defined in the Mautic configuration to the list of fonts in the Style Manager of the GrapesJS builder. Only fonts with a unique name are added to the selection. Style links for all fonts are added to the canvas, but when saving a message or landing page, only those actually used to style the document are finally added in the HTML <head>.

![fonts](https://user-images.githubusercontent.com/102536220/223714994-df5407b8-b6e6-421f-8006-d3f58abf8da1.jpg)

Example of Mautic editor_fonts: 
```
(...)
'editor_fonts' => array(
        '0' => array(
            'name' => 'Smokum',
            'font' => 'Smokum, cursive',
            'url' => 'https://fonts.googleapis.com/css2?family=Smokum&display=swap'
        ),
        '1' => array(
            'name' => 'Sofia',
            'font' => 'Sofia, sans-serif',
            'url' => 'https://fonts.googleapis.com/css?family=Sofia'
        )
),
(...)
```