### PR TITLE
Update grapesjs compatibility (Mautic 5)

### DIFF
--- a/dist/blocks.js
+++ b/dist/blocks.js
@@ -6,12 +6,13 @@ export default ((editor, opts = {}) => {
   const bm = editor.BlockManager;
   const blocks = bm.getAll();
   const mode = ContentService.getMode(editor);
+
   if (mode === ContentService.modeEmailMjml) {
     const blockMjml = new BlocksMjml(editor);
     blockMjml.addBlocks();
-  }
+  } // a add button block for landing page
 
-  // a add button block for landing page
+
   if (mode === ContentService.modePageHtml) {
     const buttonBlock = new ButtonBlock(editor);
     buttonBlock.addButtonBlock();
@@ -19,96 +20,104 @@ export default ((editor, opts = {}) => {
     // Add Dynamic Content block only for email modes
     const dcb = new DynamicContentBlocks(editor, opts);
     dcb.addDynamciContentBlock();
-  }
+  } // Add icon to mj-hero
 
-  // Add icon to mj-hero
+
   if (typeof bm.get('mj-hero') !== 'undefined') {
     bm.get('mj-hero').set({
       attributes: {
         class: 'gjs-fonts gjs-f-hero'
       }
     });
-  }
+  } // Delete mj-wrapper
 
-  // Delete mj-wrapper
+
   if (typeof bm.get('mj-wrapper') !== 'undefined') {
     bm.remove('mj-wrapper');
-  }
+  } // All block inside Blocks category
 
-  // All block inside Blocks category
+
   blocks.forEach(block => {
     block.set({
       category: Mautic.translate('grapesjsbuilder.categoryBlockLabel')
     });
   });
-
   /*
    * Custom block inside Sections category
    */
-
   // MJML columns
+
   if (typeof bm.get('mj-1-column') !== 'undefined') {
     bm.get('mj-1-column').set({
       label: Mautic.translate('grapesjsbuilder.components.names.oneColumn'),
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('mj-2-columns') !== 'undefined') {
     bm.get('mj-2-columns').set({
       label: Mautic.translate('grapesjsbuilder.components.names.twoColumn'),
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('mj-3-columns') !== 'undefined') {
     bm.get('mj-3-columns').set({
       label: Mautic.translate('grapesjsbuilder.components.names.threeColumn'),
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('mj-37-columns') !== 'undefined') {
     bm.get('mj-37-columns').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
-  }
+  } // Newsletter columns
 
-  // Newsletter columns
+
   if (typeof bm.get('sect100') !== 'undefined') {
     bm.get('sect100').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('sect50') !== 'undefined') {
     bm.get('sect50').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('sect30') !== 'undefined') {
     bm.get('sect30').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('sect37') !== 'undefined') {
     bm.get('sect37').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
-  }
+  } // Webpage columns
 
-  // Webpage columns
+
   if (typeof bm.get('column1') !== 'undefined') {
     bm.get('column1').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('column2') !== 'undefined') {
     bm.get('column2').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('column3') !== 'undefined') {
     bm.get('column3').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')
     });
   }
+
   if (typeof bm.get('column3-7') !== 'undefined') {
     bm.get('column3-7').set({
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel')

--- a/dist/blocks.js
+++ b/dist/blocks.js
@@ -1,6 +1,7 @@
 import DynamicContentBlocks from './dynamicContent/dynamicContent.blocks';
 import ContentService from './content.service';
 import ButtonBlock from './buttonBlock';
+import PanelsMjml from './panels/panels.mjml';
 import BlocksMjml from './blocks/blocks.mjml';
 export default ((editor, opts = {}) => {
   const bm = editor.BlockManager;
@@ -8,7 +9,9 @@ export default ((editor, opts = {}) => {
   const mode = ContentService.getMode(editor);
 
   if (mode === ContentService.modeEmailMjml) {
+    const panelMjml = new PanelsMjml(editor);
     const blockMjml = new BlocksMjml(editor);
+    panelMjml.restylePanels();
     blockMjml.addBlocks();
   } // a add button block for landing page
 

--- a/dist/blocks.js
+++ b/dist/blocks.js
@@ -22,7 +22,7 @@ export default ((editor, opts = {}) => {
   } else {
     // Add Dynamic Content block only for email modes
     const dcb = new DynamicContentBlocks(editor, opts);
-    dcb.addDynamciContentBlock();
+    dcb.addDynamicContentBlock();
   } // Add icon to mj-hero
 
 

--- a/dist/blocks/blocks.mjml.js
+++ b/dist/blocks/blocks.mjml.js
@@ -1,13 +1,15 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 export default class BlocksMjml {
   constructor(editor) {
     _defineProperty(this, "blockManager", void 0);
+
     _defineProperty(this, "editor", void 0);
+
     this.editor = editor;
     this.blockManager = editor.BlockManager;
   }
+
   addBlocks() {
     const sections37 = `<mj-column width="30%"><mj-text>Content 1</mj-text></mj-column>
         <mj-column width="70%"><mj-text>Content 2</mj-text></mj-column>`;
@@ -85,4 +87,5 @@ export default class BlocksMjml {
       content: `<mj-section>${listItem}</mj-section>`
     });
   }
+
 }

--- a/dist/blocks/blocks.mjml.js
+++ b/dist/blocks/blocks.mjml.js
@@ -16,10 +16,10 @@ export default class BlocksMjml {
     this.blockManager.add('mj-37-columns', {
       label: Mautic.translate('grapesjsbuilder.components.names.twoColumnThirdSevens'),
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel'),
-      attributes: {
-        class: 'gjs-fonts gjs-f-b37'
-      },
-      content: `<mj-section>${sections37}</mj-section>`
+      content: `<mj-section>${sections37}</mj-section>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M2 20h5V4H2v16Zm-1 0V4a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1ZM10 20h12V4H10v16Zm-1 0V4a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H10a1 1 0 0 1-1-1Z"></path>
+      </svg>`
     });
     const textSect = `<mj-column>
           <mj-text font-size="18px" font-weight="bold">
@@ -32,10 +32,10 @@ export default class BlocksMjml {
     this.blockManager.add('text-sect', {
       label: Mautic.translate('grapesjsbuilder.components.names.textSectionBlkLabel'),
       category: Mautic.translate('grapesjsbuilder.reusableDynamicContentBlockLabel'),
-      attributes: {
-        class: 'gjs-fonts gjs-f-h1p'
-      },
-      content: `<mj-section>${textSect}</mj-section>`
+      content: `<mj-section>${textSect}</mj-section>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4H20A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20M4,6V18H20V6H4M6,9H18V11H6V9M6,13H16V15H6V13Z" />
+      </svg>`
     });
     const gridItem = `<mj-group>
         <mj-column>
@@ -60,10 +60,10 @@ export default class BlocksMjml {
     this.blockManager.add('grid-items', {
       label: Mautic.translate('grapesjsbuilder.components.names.gridItemsBlkLabel'),
       category: Mautic.translate('grapesjsbuilder.reusableDynamicContentBlockLabel'),
-      attributes: {
-        class: 'fa fa-th'
-      },
-      content: `<mj-section>${gridItem}</mj-section>`
+      content: `<mj-section>${gridItem}</mj-section>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M3,11H11V3H3M3,21H11V13H3M13,21H21V13H13M13,3V11H21V3"/>
+      </svg>`
     });
     const listItem = `<mj-group>
         <mj-column width="30%">
@@ -81,10 +81,10 @@ export default class BlocksMjml {
     this.blockManager.add('list-items', {
       label: Mautic.translate('grapesjsbuilder.components.names.listItemsBlkLabel'),
       category: Mautic.translate('grapesjsbuilder.reusableDynamicContentBlockLabel'),
-      attributes: {
-        class: 'fa fa-th-list'
-      },
-      content: `<mj-section>${listItem}</mj-section>`
+      content: `<mj-section>${listItem}</mj-section>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M2 14H8V20H2M16 8H10V10H16M2 10H8V4H2M10 4V6H22V4M10 20H16V18H10M10 16H22V14H10"/>
+      </svg>`
     });
   }
 

--- a/dist/buttonBlock.js
+++ b/dist/buttonBlock.js
@@ -1,11 +1,12 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 export default class ButtonBlock {
   constructor(editor) {
     _defineProperty(this, "blockManager", void 0);
+
     this.blockManager = editor.BlockManager;
   }
+
   addButtonBlock() {
     const style = `<style>
                       .button {
@@ -32,4 +33,5 @@ export default class ButtonBlock {
          <a href="#" target="_blank" class="button">Button</a>`
     });
   }
+
 }

--- a/dist/buttonBlock.js
+++ b/dist/buttonBlock.js
@@ -30,7 +30,10 @@ export default class ButtonBlock {
         class: 'gjs-fonts gjs-f-button'
       },
       content: `${style}
-         <a href="#" target="_blank" class="button">Button</a>`
+         <a href="#" target="_blank" class="button">Button</a>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M20 20.5C20 21.3 19.3 22 18.5 22H13C12.6 22 12.3 21.9 12 21.6L8 17.4L8.7 16.6C8.9 16.4 9.2 16.3 9.5 16.3H9.7L12 18V9C12 8.4 12.4 8 13 8S14 8.4 14 9V13.5L15.2 13.6L19.1 15.8C19.6 16 20 16.6 20 17.1V20.5M20 2H4C2.9 2 2 2.9 2 4V12C2 13.1 2.9 14 4 14H8V12H4V4H20V12H18V14H20C21.1 14 22 13.1 22 12V4C22 2.9 21.1 2 20 2Z" />
+    </svg>`
     });
   }
 

--- a/dist/buttons.js
+++ b/dist/buttons.js
@@ -140,12 +140,12 @@ export default ((editor, opts = {}) => {
 
       const traitsSector = $('<div class="gjs-sm-sector no-select">' + '<div class="gjs-sm-title"><span class="icon-settings fa fa-cog"></span> Settings</div>' + '<div class="gjs-sm-properties" style="display: none;"></div></div>');
       const traitsProps = traitsSector.find('.gjs-sm-properties');
-      const traits = $('.gjs-trt-traits');
+      const traits = $('.gjs-trt-traits'); // we can only show the Settings, if something in the template is selected
+      // otherwise we're going to get an error about trying to append a non-existing node
 
       if (traitsProps.length && traits.length) {
         traitsProps.append(traits);
-        const sectors = $('.gjs-sm-sectors'); // we can only show the Settings, if something in the template is selected
-        // otherwise we're trying to append stuff to nothing and get errors
+        const sectors = $('.gjs-sm-sectors');
 
         if (sectors.length) {
           sectors.before(traitsSector);

--- a/dist/buttons.js
+++ b/dist/buttons.js
@@ -6,40 +6,38 @@ export default ((editor, opts = {}) => {
     $
   } = editor;
   const pm = editor.Panels;
-  const defaultPanel = opts.defaultPanel || 'open-blocks';
+  const defaultPanel = opts.defaultPanel || 'open-blocks'; // Disable Import code button
 
-  // Disable Import code button
   if (!opts.showImportButton) {
     const mjmlImportBtn = pm.getButton('options', 'mjml-import');
     const htmlImportBtn = pm.getButton('options', 'gjs-open-import-template');
-    const pageImportBtn = pm.getButton('options', 'gjs-open-import-webpage');
+    const pageImportBtn = pm.getButton('options', 'gjs-open-import-webpage'); // MJML import
 
-    // MJML import
     if (mjmlImportBtn !== null) {
       pm.removeButton('options', 'mjml-import');
-    }
+    } // Newsletter import
 
-    // Newsletter import
+
     if (htmlImportBtn !== null) {
       pm.removeButton('options', 'gjs-open-import-template');
-    }
+    } // Webpage import
 
-    // Webpage import
+
     if (pageImportBtn !== null) {
       pm.removeButton('options', 'gjs-open-import-webpage');
     }
-  }
-
-  // disable useless export button since not all of .then(function (response) {
+  } // disable useless export button since not all of .then(function (response) {
   // template is exportet (in favour of code editor)
   // Causes issue: https://github.com/artf/grapesjs/issues/3444
   // @todo Possible workaround: hide it with css
   // editor.Panels.getButton('options', 'export-template').attributes.className = 'hide_panel_btn'
   // pm.removeButton('options', 'export-template');
-
   // Move Undo & Redo inside Commands Panel
+
+
   const undo = pm.getButton('options', 'undo');
   const redo = pm.getButton('options', 'redo');
+
   if (undo !== null) {
     pm.removeButton('options', 'undo');
     pm.addButton('commands', [{
@@ -48,11 +46,14 @@ export default ((editor, opts = {}) => {
       attributes: {
         title: 'Undo'
       },
+
       command() {
         editor.runCommand('core:undo');
       }
+
     }]);
   }
+
   if (redo !== null) {
     pm.removeButton('options', 'redo');
     pm.addButton('commands', [{
@@ -61,75 +62,82 @@ export default ((editor, opts = {}) => {
       attributes: {
         title: 'Redo'
       },
+
       command() {
         editor.runCommand('core:redo');
       }
-    }]);
-  }
 
-  // Remove preview button (because they are dublicated?)
+    }]);
+  } // Remove preview button (because they are dublicated?)
+
+
   const preview = pm.getButton('options', 'preview');
+
   if (preview !== null) {
     pm.removeButton('options', 'preview');
-  }
+  } // Remove clear button
 
-  // Remove clear button
+
   const clear = pm.getButton('options', 'canvas-clear');
+
   if (clear !== null) {
     pm.removeButton('options', 'canvas-clear');
-  }
+  } // Remove toggle images button
 
-  // Remove toggle images button
+
   const toggleImages = pm.getButton('options', 'gjs-toggle-images');
+
   if (toggleImages !== null) {
     pm.removeButton('options', 'gjs-toggle-images');
-  }
-  // add editor preview button
+  } // add editor preview button
+
+
   const btnPreview = new ButtonPreview(editor);
   btnPreview.addCommand();
-  btnPreview.addButton();
+  btnPreview.addButton(); // add editor apply button
 
-  // add editor apply button
   const btnApply = new ButtonApply(editor);
   btnApply.addCommand();
-  btnApply.addButton();
+  btnApply.addButton(); // add editor close button
 
-  // add editor close button
   const btnClose = new ButtonClose(editor);
   btnClose.addCommand();
-  btnClose.addButton();
+  btnClose.addButton(); // Do stuff on load
 
-  // Do stuff on load
   editor.on('load', () => {
     // Hide Layers Manager
     if (!opts.showLayersManager) {
       const openLayersBtn = pm.getButton('views', 'open-layers');
+
       if (openLayersBtn !== null) {
         openLayersBtn.set('attributes', {
           style: 'display:none;'
         });
       }
-    }
+    } // Activate by default View Components button
 
-    // Activate by default View Components button
+
     const viewComponents = pm.getButton('options', 'sw-visibility');
+
     if (viewComponents) {
       viewComponents.set('active', 1);
-    }
+    } // Load and show settings and style manager
 
-    // Load and show settings and style manager
+
     if (!opts.combineSettingsAndSm) {
       const openTmBtn = pm.getButton('views', 'open-tm');
       const openSm = pm.getButton('views', 'open-sm');
+
       if (openTmBtn) {
         openTmBtn.set('active', 1);
       }
+
       if (openSm) {
         openSm.set('active', 1);
       }
-      pm.removeButton('views', 'open-tm');
 
-      // Add Settings Sector
+      pm.removeButton('views', 'open-tm'); // Add Settings Sector
+
       const traitsSector = $('<div class="gjs-sm-sector no-select">' + '<div class="gjs-sm-title"><span class="icon-settings fa fa-cog"></span> Settings</div>' + '<div class="gjs-sm-properties" style="display: none;"></div></div>');
       const traitsProps = traitsSector.find('.gjs-sm-properties');
       traitsProps.append($('.gjs-trt-traits'));
@@ -137,19 +145,20 @@ export default ((editor, opts = {}) => {
       traitsSector.find('.gjs-sm-title').on('click', () => {
         const traitStyle = traitsProps.get(0).style;
         const hidden = traitStyle.display === 'none';
+
         if (hidden) {
           traitStyle.display = 'block';
         } else {
           traitStyle.display = 'none';
         }
-      });
+      }); // Open settings
 
-      // Open settings
       traitsProps.get(0).style.display = 'block';
-    }
+    } // Open the default panel
 
-    // Open the default panel
+
     const openBlocksBtn = editor.Panels.getButton('views', defaultPanel);
+
     if (openBlocksBtn) {
       openBlocksBtn.set('active', 1);
     }

--- a/dist/buttons.js
+++ b/dist/buttons.js
@@ -140,20 +140,29 @@ export default ((editor, opts = {}) => {
 
       const traitsSector = $('<div class="gjs-sm-sector no-select">' + '<div class="gjs-sm-title"><span class="icon-settings fa fa-cog"></span> Settings</div>' + '<div class="gjs-sm-properties" style="display: none;"></div></div>');
       const traitsProps = traitsSector.find('.gjs-sm-properties');
-      traitsProps.append($('.gjs-trt-traits'));
-      $('.gjs-sm-sectors').before(traitsSector);
-      traitsSector.find('.gjs-sm-title').on('click', () => {
-        const traitStyle = traitsProps.get(0).style;
-        const hidden = traitStyle.display === 'none';
+      const traits = $('.gjs-trt-traits');
 
-        if (hidden) {
-          traitStyle.display = 'block';
-        } else {
-          traitStyle.display = 'none';
+      if (traitsProps.length && traits.length) {
+        traitsProps.append(traits);
+        const sectors = $('.gjs-sm-sectors'); // we can only show the Settings, if something in the template is selected
+        // otherwise we're trying to append stuff to nothing and get errors
+
+        if (sectors.length) {
+          sectors.before(traitsSector);
+          traitsSector.find('.gjs-sm-title').on('click', () => {
+            const traitStyle = traitsProps.get(0).style;
+            const hidden = traitStyle.display === 'none';
+
+            if (hidden) {
+              traitStyle.display = 'block';
+            } else {
+              traitStyle.display = 'none';
+            }
+          }); // Open settings
+
+          traitsProps.get(0).style.display = 'block';
         }
-      }); // Open settings
-
-      traitsProps.get(0).style.display = 'block';
+      }
     } // Open the default panel
 
 

--- a/dist/buttons.js
+++ b/dist/buttons.js
@@ -125,6 +125,9 @@ export default ((editor, opts = {}) => {
 
 
     if (!opts.combineSettingsAndSm) {
+      // Add Settings Sector
+      const traitsSector = $('<div class="gjs-sm-sector no-select">' + '<div class="gjs-sm-title"><span class="icon-settings fa fa-cog"></span> Settings</div>' + '<div class="gjs-sm-properties" style="display: none;"></div></div>');
+      const traitsProps = traitsSector.find('.gjs-sm-properties');
       const openTmBtn = pm.getButton('views', 'open-tm');
       const openSm = pm.getButton('views', 'open-sm');
 
@@ -136,32 +139,24 @@ export default ((editor, opts = {}) => {
         openSm.set('active', 1);
       }
 
-      pm.removeButton('views', 'open-tm'); // Add Settings Sector
+      pm.removeButton('views', 'open-tm');
+      traitsProps.append($('.gjs-traits-cs')); // we can only show the Settings, if something in the template is selected
+      // otherwise we're trying to append stuff to nothing and get errors
 
-      const traitsSector = $('<div class="gjs-sm-sector no-select">' + '<div class="gjs-sm-title"><span class="icon-settings fa fa-cog"></span> Settings</div>' + '<div class="gjs-sm-properties" style="display: none;"></div></div>');
-      const traitsProps = traitsSector.find('.gjs-sm-properties');
-      const traits = $('.gjs-trt-traits'); // we can only show the Settings, if something in the template is selected
-      // otherwise we're going to get an error about trying to append a non-existing node
+      if ($('.gjs-sm-sectors').length) {
+        $('.gjs-sm-sectors').before(traitsSector);
+        traitsSector.find('.gjs-sm-title').on('click', () => {
+          const traitStyle = traitsProps.get(0).style;
+          const hidden = traitStyle.display === 'none';
 
-      if (traitsProps.length && traits.length) {
-        traitsProps.append(traits);
-        const sectors = $('.gjs-sm-sectors');
+          if (hidden) {
+            traitStyle.display = 'block';
+          } else {
+            traitStyle.display = 'none';
+          }
+        }); // Open settings
 
-        if (sectors.length) {
-          sectors.before(traitsSector);
-          traitsSector.find('.gjs-sm-title').on('click', () => {
-            const traitStyle = traitsProps.get(0).style;
-            const hidden = traitStyle.display === 'none';
-
-            if (hidden) {
-              traitStyle.display = 'block';
-            } else {
-              traitStyle.display = 'none';
-            }
-          }); // Open settings
-
-          traitsProps.get(0).style.display = 'block';
-        }
+        traitsProps.get(0).style.display = 'block';
       }
     } // Open the default panel
 

--- a/dist/buttons/buttonApply.command.js
+++ b/dist/buttons/buttonApply.command.js
@@ -1,6 +1,5 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import ContentService from '../content.service';
 import MjmlService from '../mjml/mjml.service';
 import ButtonCloseCommands from './buttonClose.command';
@@ -18,20 +17,23 @@ export default class ButtonApplyCommand {
    */
   static applyForm(editor, sender) {
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
+
     if (ContentService.isMjmlMode(editor)) {
       const htmlCode = MjmlService.getEditorHtmlContent(editor);
       const mjmlCode = MjmlService.getEditorMjmlContent(editor);
+
       if (!htmlCode || !mjmlCode) {
         throw new Error('Could not generate html from MJML');
       }
+
       ButtonCloseCommands.returnContentToTextarea(editor, htmlCode, mjmlCode);
     } else {
       const html = ContentService.getEditorHtmlContent(editor);
       ButtonCloseCommands.returnContentToTextarea(editor, html);
     }
+
     ButtonApplyCommand.postForm(editor, sender);
   }
-
   /**
    * Send POST request for sending the form, get and handle response
    * Use the global Mautic postForm function
@@ -39,6 +41,8 @@ export default class ButtonApplyCommand {
    * @param editor
    * @param sender
    */
+
+
   static postForm(editor, sender) {
     const mauticForm = ButtonsService.getMauticForm();
     sender.set('className', 'fa fa-spinner fa-spin');
@@ -47,7 +51,6 @@ export default class ButtonApplyCommand {
     Mautic.postForm(mauticForm, ButtonApplyCommand.postFormResponse.bind(this, editor, sender));
     Mautic.inBuilderSubmissionOff();
   }
-
   /**
    * Get and handle response
    * Use the global Mautic functions
@@ -56,8 +59,11 @@ export default class ButtonApplyCommand {
    * @param sender
    * @param response
    */
+
+
   static postFormResponse(editor, sender, response) {
     const mauticForm = ButtonsService.getMauticForm();
+
     if (response.validationError !== null) {
       const title = Mautic.translate('grapesjsbuilder.panelsViewsCommandModalTitleError');
       ButtonApplyCommand.showModal(editor, title, response.validationError);
@@ -65,20 +71,19 @@ export default class ButtonApplyCommand {
       if (response.route) {
         // update URL in address bar
         MauticVars.manualStateChange = false;
-        History.pushState(null, 'Mautic', response.route);
+        History.pushState(null, 'Mautic', response.route); // update Title
 
-        // update Title
         Mautic.generatePageTitle(response.route);
-      }
+      } // update form action
 
-      // update form action
+
       if (mauticForm[0].baseURI !== mauticForm[0].action) {
         mauticForm[0].action = mauticForm[0].baseURI;
       }
     }
+
     sender.set('className', 'fa fa-check');
   }
-
   /**
    * Create modal to show information about saving email
    *
@@ -86,6 +91,8 @@ export default class ButtonApplyCommand {
    * @param title
    * @param text
    */
+
+
   static showModal(editor, title, text) {
     const modal = editor.Modal;
     const body = document.createElement('div');
@@ -98,9 +105,11 @@ export default class ButtonApplyCommand {
     body.appendChild(content);
     btnClose.classList.add('btn', 'btn-lg', 'btn-default', 'text-primary');
     btnClose.innerText = 'Close';
+
     btnClose.onclick = () => {
       modal.close();
     };
+
     footer.classList.add('panel-footer', 'text-center');
     footer.appendChild(btnClose);
     body.appendChild(footer);
@@ -111,30 +120,38 @@ export default class ButtonApplyCommand {
       }
     });
   }
-
   /**
    * Set a default value for the required form items.
    * The email form has subject and internal name fields as a required.
    * The page form has a title field as a required.
    */
+
+
   static setDefaultValues(editor) {
     const mode = ContentService.getMode(editor);
+
     if (mode === ContentService.modeEmailHtml || mode === ContentService.modeEmailMjml) {
       let formEmailSubject = ButtonsService.getElementValue('emailform_subject');
       let formEmailName = ButtonsService.getElementValue('emailform_name');
+
       if (formEmailSubject.lenght === 0) {
         formEmailSubject = ButtonsService.getDefaultValue(mode.split('-')[0]);
       }
+
       if (formEmailName.length === 0) {
         formEmailName = ButtonsService.getDefaultValue(mode.split('-')[0]);
       }
     }
+
     if (mode === ContentService.modePageHtml) {
       let formPageTitle = ButtonsService.getElementValue('page_title');
+
       if (formPageTitle.length === 0) {
         formPageTitle = ButtonsService.getDefaultValue(mode.split('-')[0]);
       }
     }
   }
+
 }
+
 _defineProperty(ButtonApplyCommand, "name", 'preset-mautic:apply-form');

--- a/dist/buttons/buttonApply.command.js
+++ b/dist/buttons/buttonApply.command.js
@@ -1,11 +1,14 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import ContentService from '../content.service';
 import MjmlService from '../mjml/mjml.service';
 import ButtonCloseCommands from './buttonClose.command';
 import ButtonsService from './buttons.service';
 export default class ButtonApplyCommand {
+  /**
+   * The command name
+   */
+
   /**
    * Command saves the email into Database
    *
@@ -14,20 +17,23 @@ export default class ButtonApplyCommand {
    */
   static applyForm(editor, sender) {
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
+
     if (ContentService.isMjmlMode(editor)) {
       const htmlCode = MjmlService.getEditorHtmlContent(editor);
       const mjmlCode = MjmlService.getEditorMjmlContent(editor);
+
       if (!htmlCode || !mjmlCode) {
         throw new Error('Could not generate html from MJML');
       }
+
       ButtonCloseCommands.returnContentToTextarea(editor, htmlCode, mjmlCode);
     } else {
       const html = ContentService.getEditorHtmlContent(editor);
       ButtonCloseCommands.returnContentToTextarea(editor, html);
     }
+
     ButtonApplyCommand.postForm(editor, sender);
   }
-
   /**
    * Send POST request for sending the form, get and handle response
    * Use the global Mautic postForm function
@@ -35,6 +41,8 @@ export default class ButtonApplyCommand {
    * @param editor
    * @param sender
    */
+
+
   static postForm(editor, sender) {
     const mauticForm = ButtonsService.getMauticForm();
     sender.set('className', 'fa fa-spinner fa-spin');
@@ -43,7 +51,6 @@ export default class ButtonApplyCommand {
     Mautic.postForm(mauticForm, ButtonApplyCommand.postFormResponse.bind(this, editor, sender));
     Mautic.inBuilderSubmissionOff();
   }
-
   /**
    * Get and handle response
    * Use the global Mautic functions
@@ -52,8 +59,11 @@ export default class ButtonApplyCommand {
    * @param sender
    * @param response
    */
+
+
   static postFormResponse(editor, sender, response) {
     const mauticForm = ButtonsService.getMauticForm();
+
     if (response.validationError !== null) {
       const title = Mautic.translate('grapesjsbuilder.panelsViewsCommandModalTitleError');
       ButtonApplyCommand.showModal(editor, title, response.validationError);
@@ -61,20 +71,19 @@ export default class ButtonApplyCommand {
       if (response.route) {
         // update URL in address bar
         MauticVars.manualStateChange = false;
-        history.pushState(null, 'Mautic', response.route);
+        history.pushState(null, 'Mautic', response.route); // update Title
 
-        // update Title
         Mautic.generatePageTitle(response.route);
-      }
+      } // update form action
 
-      // update form action
+
       if (mauticForm[0].baseURI !== mauticForm[0].action) {
         mauticForm[0].action = mauticForm[0].baseURI;
       }
     }
+
     sender.set('className', 'fa fa-check');
   }
-
   /**
    * Create modal to show information about saving email
    *
@@ -82,6 +91,8 @@ export default class ButtonApplyCommand {
    * @param title
    * @param text
    */
+
+
   static showModal(editor, title, text) {
     const modal = editor.Modal;
     const body = document.createElement('div');
@@ -94,9 +105,11 @@ export default class ButtonApplyCommand {
     body.appendChild(content);
     btnClose.classList.add('btn', 'btn-lg', 'btn-default', 'text-primary');
     btnClose.innerText = 'Close';
+
     btnClose.onclick = () => {
       modal.close();
     };
+
     footer.classList.add('panel-footer', 'text-center');
     footer.appendChild(btnClose);
     body.appendChild(footer);
@@ -107,36 +120,41 @@ export default class ButtonApplyCommand {
       }
     });
   }
-
   /**
    * Set a default value for the required form items.
    * The email form has subject and internal name fields as a required.
    * The page form has a title field as a required.
    */
+
+
   static setDefaultValues(editor) {
     const mode = ContentService.getMode(editor);
+
     if (mode === ContentService.modeEmailHtml || mode === ContentService.modeEmailMjml) {
       let formEmailSubject = ButtonsService.getElementValue('emailform_subject');
       let formEmailName = ButtonsService.getElementValue('emailform_name');
+
       if (formEmailSubject.length === 0) {
         formEmailSubject = ButtonsService.getDefaultValue(mode.split('-')[0]);
         ButtonsService.setElementValue('emailform_subject', formEmailSubject);
       }
+
       if (formEmailName.length === 0) {
         formEmailName = ButtonsService.getDefaultValue(mode.split('-')[0]);
         ButtonsService.setElementValue('emailform_name', formEmailName);
       }
     }
+
     if (mode === ContentService.modePageHtml) {
       let formPageTitle = ButtonsService.getElementValue('page_title');
+
       if (formPageTitle.length === 0) {
         formPageTitle = ButtonsService.getDefaultValue(mode.split('-')[0]);
         ButtonsService.setElementValue('page_title', formPageTitle);
       }
     }
   }
+
 }
-/**
- * The command name
- */
+
 _defineProperty(ButtonApplyCommand, "name", 'preset-mautic:apply-form');

--- a/dist/buttons/buttonApply.js
+++ b/dist/buttons/buttonApply.js
@@ -1,33 +1,36 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import ButtonApplyCommand from './buttonApply.command';
 import ButtonsService from './buttons.service';
 import ContentService from '../content.service';
 export default class ButtonApply {
   constructor(editor) {
     _defineProperty(this, "editor", void 0);
+
     if (!editor) {
       throw new Error('no editor');
     }
+
     this.editor = editor;
   }
-
   /**
    * Add the save button before the close button
    */
+
+
   addButton() {
     const emailTypeSegment = 'list';
     const mode = ContentService.getMode(this.editor);
     let title = Mautic.translate('grapesjsbuilder.panelsViewsButtonsApplyTitle');
     let disable = false;
     let command = ButtonApply.getCommand();
-    if (mode === ContentService.modeEmailHtml || mode === ContentService.modeEmailMjml) {
-      const emailType = ButtonsService.getElementValue('emailform_emailType');
 
-      // if it is a segment email, check if segment field is filled
+    if (mode === ContentService.modeEmailHtml || mode === ContentService.modeEmailMjml) {
+      const emailType = ButtonsService.getElementValue('emailform_emailType'); // if it is a segment email, check if segment field is filled
+
       if (emailType === emailTypeSegment) {
         const emailFormList = ButtonsService.getElementValue('emailform_lists');
+
         if (emailFormList.length === 0) {
           title = Mautic.translate('grapesjsbuilder.panelsViewsButtonsApplyTitleError');
           disable = true;
@@ -35,6 +38,7 @@ export default class ButtonApply {
         }
       }
     }
+
     this.editor.Panels.addButton('views', [{
       id: 'views-apply',
       className: `fa fa-check`,
@@ -48,27 +52,31 @@ export default class ButtonApply {
       context: 'views-apply'
     }]);
   }
+
   addCommand() {
     this.editor.Commands.add(ButtonApplyCommand.name, {
       run: ButtonApply.getCallback()
     });
   }
-
   /**
    * Get the apply command name based on the editor mode
    *
    * @returns String
    */
+
+
   static getCommand() {
     return ButtonApplyCommand.name;
   }
-
   /**
    * Get the actual Command/Function to be executed on closing of the editor
    *
    * @returns Function
    */
+
+
   static getCallback() {
     return ButtonApplyCommand.applyForm;
   }
+
 }

--- a/dist/buttons/buttonClose.command.js
+++ b/dist/buttons/buttonClose.command.js
@@ -6,33 +6,44 @@ export default class ButtonCloseCommands {
     if (!editor) {
       throw new Error('no page-html editor');
     }
+
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
     const htmlDocument = ContentService.getCanvasAsHtmlDocument(editor);
     let htmlString = ContentService.serializeHtmlDocument(htmlDocument);
+
     if (mauticEditorFonts) {
       htmlString = EditorFontsService.addFontLinksToHtml(htmlString);
     }
+
     ButtonCloseCommands.returnContentToTextarea(editor, htmlString); // Reset HTML
+
     ButtonCloseCommands.resetHtml(editor);
   }
+
   static closeEditorEmailHtml(editor) {
     if (!editor) {
       throw new Error('No email-HTML editor');
     }
-    editor.runCommand('preset-mautic:dynamic-content-components-to-tokens'); // Getting HTML with CSS inline (only available for "grapesjs-preset-newsletter"):
 
+    editor.runCommand('preset-mautic:dynamic-content-components-to-tokens'); // Getting HTML with CSS inline (only available for "grapesjs-preset-newsletter"):
     // Getting HTML with CSS inline (only available for "grapesjs-preset-newsletter"):
+
     let html = ContentService.getEditorHtmlContent(editor);
+
     if (mauticEditorFonts) {
       html = EditorFontsService.addFontLinksToHtml(html);
     }
+
     ButtonCloseCommands.returnContentToTextarea(editor, html); // Reset HTML
+
     ButtonCloseCommands.resetHtml(editor);
   }
+
   static closeEditorEmailMjml(editor) {
     if (!editor) {
       throw new Error('No email-MJML editor');
     }
+
     editor.runCommand('preset-mautic:dynamic-content-components-to-tokens');
     let htmlCode = MjmlService.getEditorHtmlContent(editor);
     const mjmlCode = MjmlService.getEditorMjmlContent(editor); // Update textarea for save
@@ -40,18 +51,22 @@ export default class ButtonCloseCommands {
     if (!htmlCode || !mjmlCode) {
       throw new Error('Could not generate html from MJML');
     }
+
     if (mauticEditorFonts) {
       htmlCode = EditorFontsService.addFontLinksToHtml(htmlCode);
     }
+
     ButtonCloseCommands.returnContentToTextarea(editor, htmlCode, mjmlCode); // Reset HTML
+
     ButtonCloseCommands.resetHtml(editor);
   }
-
   /**
    * Save the html and mjml
    * @param {string} html
    * @param {string} mjml
    */
+
+
   static returnContentToTextarea(editor, html, mjml) {
     if (ContentService.isMjmlMode(editor)) {
       mQuery('textarea.builder-html').val(html);
@@ -60,13 +75,12 @@ export default class ButtonCloseCommands {
       mQuery('textarea.builder-html').val(html);
     }
   }
+
   static resetHtml() {
     mQuery('.builder').removeClass('builder-active').addClass('hide');
     mQuery('html').css('font-size', '');
     mQuery('body').css('overflow-y', '');
-    mQuery('.builder-panel').css('display', 'none');
-
-    // Destroy GrapesJS
+    mQuery('.builder-panel').css('display', 'none'); // Destroy GrapesJS
     // Dont destroy grapesjs. Just hide it. Will be auto destroyed if user
     // loads a new page.
     // workaround: throws typeError: Cannot read property 'trigger'
@@ -74,4 +88,5 @@ export default class ButtonCloseCommands {
     // setTimeout(() => editor.destroy(), 1000);
     // editor.destroy();
   }
+
 }

--- a/dist/buttons/buttonClose.js
+++ b/dist/buttons/buttonClose.js
@@ -1,6 +1,5 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 /* eslint-disable no-else-return */
 import ContentService from '../content.service';
 import ButtonCloseCommands from './buttonClose.command';
@@ -14,13 +13,17 @@ export default class ButtonClose {
    */
   constructor(editor) {
     _defineProperty(this, "editor", void 0);
+
     _defineProperty(this, "command", void 0);
+
     if (!editor) {
       throw new Error('no editor');
     }
+
     this.editor = editor;
     this.command = this.getCommand();
   }
+
   addButton() {
     this.editor.Panels.addButton('views', [{
       id: 'close',
@@ -31,43 +34,54 @@ export default class ButtonClose {
       command: this.command
     }]);
   }
+
   addCommand() {
     this.editor.Commands.add(this.command, {
       run: this.getCallback()
     });
   }
-
   /**
    * Get the close command based on the editor mode
    */
+
+
   getCommand() {
     const mode = ContentService.getMode(this.editor);
+
     if (mode === ContentService.modePageHtml) {
       return 'mautic-editor-page-html-close';
     }
+
     if (mode === ContentService.modeEmailHtml) {
       return 'mautic-editor-email-html-close';
     }
+
     if (mode === ContentService.modeEmailMjml) {
       return 'mautic-editor-email-mjml-close';
     }
+
     throw new Error(`no valid builder mode: ${mode}`);
   }
-
   /**
    * get the actual Command/Function to be executed on closing of the editor
    * @returns Function
    */
+
+
   getCallback() {
     if (this.command === 'mautic-editor-page-html-close') {
       return ButtonCloseCommands.closeEditorPageHtml;
     }
+
     if (this.command === 'mautic-editor-email-html-close') {
       return ButtonCloseCommands.closeEditorEmailHtml;
     }
+
     if (this.command === 'mautic-editor-email-mjml-close') {
       return ButtonCloseCommands.closeEditorEmailMjml;
     }
+
     throw new Error(`no valid command: ${this.command}`);
   }
+
 }

--- a/dist/buttons/buttonPreview.command.js
+++ b/dist/buttons/buttonPreview.command.js
@@ -1,6 +1,5 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import ButtonsService from './buttons.service';
 import ContentService from '../content.service';
 export default class ButtonPreviewCommand {
@@ -18,17 +17,20 @@ export default class ButtonPreviewCommand {
     const instanceId = ButtonsService.getInstanceId(form);
     ButtonPreviewCommand.openPreview(editor, instanceId);
   }
-
   /**
    * Open  the email preview
    *
    * @param editor
    * @param emailId
    */
+
+
   static openPreview(editor, emailId) {
     const mode = ContentService.getMode(editor);
     const url = `${window.location.origin}${mauticBaseUrl}${mode.split('-')[0]}/preview/${emailId}`;
     window.open(url, '_blank');
   }
+
 }
+
 _defineProperty(ButtonPreviewCommand, "name", 'preset-mautic:preview-form');

--- a/dist/buttons/buttonPreview.js
+++ b/dist/buttons/buttonPreview.js
@@ -1,30 +1,34 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import ButtonPreviewCommand from './buttonPreview.command';
 import ButtonApplyCommand from './buttonApply.command';
 import ButtonsService from './buttons.service';
 export default class ButtonPreview {
   constructor(editor) {
     _defineProperty(this, "editor", void 0);
+
     if (!editor) {
       throw new Error('no editor');
     }
+
     this.editor = editor;
   }
-
   /**
    * Add the preview button
    */
+
+
   addButton() {
     let title = Mautic.translate('grapesjsbuilder.buttons.buttonPreview.title');
     let disable = false;
     let command = ButtonPreview.getCommand();
+
     if (ButtonsService.isNewEntity()) {
       title = Mautic.translate('grapesjsbuilder.buttons.buttonPreview.titleDisabled');
       disable = true;
       command = '';
     }
+
     this.editor.Panels.addButton('devices-c', [{
       id: 'devices-c-preview',
       className: `fa fa-external-link`,
@@ -44,31 +48,35 @@ export default class ButtonPreview {
       }
     });
   }
-
   /**
    * Add Preview command
    */
+
+
   addCommand() {
     this.editor.Commands.add(ButtonPreviewCommand.name, {
       run: ButtonPreview.getCallback()
     });
   }
-
   /**
    * Get the Preview command name based on the editor mode
    *
    * @returns String
    */
+
+
   static getCommand() {
     return ButtonPreviewCommand.name;
   }
-
   /**
    * Get the actual Command/Function to be executed on closing of the editor
    *
    * @returns Function
    */
+
+
   static getCallback() {
     return ButtonPreviewCommand.previewForm;
   }
+
 }

--- a/dist/buttons/buttons.service.js
+++ b/dist/buttons/buttons.service.js
@@ -7,78 +7,88 @@ export default class ButtonService {
   static getForm() {
     return document.getElementsByName('emailform').length ? document.getElementsByName('emailform') : document.getElementsByName('page');
   }
-
   /**
    * Get a form fields value by ID
    * @param string elementId
    * @return string
    */
+
+
   static getElementValue(elementId) {
     const field = document.getElementById(elementId);
+
     if (!field) {
       throw new Error(`Element '${elementId}' not found`);
     }
+
     return field.value;
   }
-
   /**
    * Get the email|page id to open preview
    *
    * @return string|null
    */
+
+
   static getInstanceId(form) {
     const url = form[0].action;
     const regexpEmailId = /(emails|pages)\/edit\/(\d+)$/g;
     const match = regexpEmailId.exec(url);
     return match ? match[2] : null;
   }
-
   /**
    * Get jQuery email form object
    * Sent as a parameter to the Mautic functions
    *
    * @return object
    */
+
+
   static getMauticForm() {
     return mQuery('form[name=emailform]').length ? mQuery('form[name=emailform]') : mQuery('form[name=page]');
   }
-
   /**
    * Check if the the entity ID is temporary (for new entities)
    *
    * @return array|null
    */
+
+
   static isNewEntity() {
     return Mautic.isNewEntity('#page_sessionId, #emailform_sessionId');
   }
-
   /**
    * Generate a default value
    *
    * @return string
    */
+
+
   static getDefaultValue(value) {
     const item = ButtonService.capitalizeFirstLetter(value);
     const date = ButtonService.getCurrentDate();
     return `${item} ${date}`;
   }
-
   /**
    * Replace the first letter with a capital letter
    *
    * @return string
    */
+
+
   static capitalizeFirstLetter(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
   }
-
   /**
    * Get the current date
    *
    * @return string
    */
+
+
   static getCurrentDate() {
     const today = new Date();
     return today.toLocaleString();
   }
+
 }

--- a/dist/buttons/buttons.service.js
+++ b/dist/buttons/buttons.service.js
@@ -23,17 +23,20 @@ export default class ButtonService {
 
     return field.value;
   }
-
   /**
    * Set a form fields value by ID
    * @param elementId
    * @param value
    */
+
+
   static setElementValue(elementId, value) {
     const field = document.getElementById(elementId);
+
     if (!field) {
       throw new Error(`Element '${elementId}' not found`);
     }
+
     field.value = value;
   }
   /**

--- a/dist/buttons/buttons.service.js
+++ b/dist/buttons/buttons.service.js
@@ -7,20 +7,22 @@ export default class ButtonService {
   static getForm() {
     return document.getElementsByName('emailform').length ? document.getElementsByName('emailform') : document.getElementsByName('page');
   }
-
   /**
    * Get a form fields value by ID
    * @param string elementId
    * @return string
    */
+
+
   static getElementValue(elementId) {
     const field = document.getElementById(elementId);
+
     if (!field) {
       throw new Error(`Element '${elementId}' not found`);
     }
+
     return field.value;
   }
-
   /**
    * Set a form fields value by ID
    * @param elementId
@@ -39,59 +41,67 @@ export default class ButtonService {
    *
    * @return string|null
    */
+
+
   static getInstanceId(form) {
     const url = form[0].action;
     const regexpEmailId = /(emails|pages)\/edit\/(\d+)$/g;
     const match = regexpEmailId.exec(url);
     return match ? match[2] : null;
   }
-
   /**
    * Get jQuery email form object
    * Sent as a parameter to the Mautic functions
    *
    * @return object
    */
+
+
   static getMauticForm() {
     return mQuery('form[name=emailform]').length ? mQuery('form[name=emailform]') : mQuery('form[name=page]');
   }
-
   /**
    * Check if the the entity ID is temporary (for new entities)
    *
    * @return array|null
    */
+
+
   static isNewEntity() {
     return Mautic.isNewEntity('#page_sessionId, #emailform_sessionId');
   }
-
   /**
    * Generate a default value
    *
    * @return string
    */
+
+
   static getDefaultValue(value) {
     const item = ButtonService.capitalizeFirstLetter(value);
     const date = ButtonService.getCurrentDate();
     return `${item} ${date}`;
   }
-
   /**
    * Replace the first letter with a capital letter
    *
    * @return string
    */
+
+
   static capitalizeFirstLetter(string) {
     return string.charAt(0).toUpperCase() + string.slice(1);
   }
-
   /**
    * Get the current date
    *
    * @return string
    */
+
+
   static getCurrentDate() {
     const today = new Date();
     return today.toLocaleString();
   }
+
 }

--- a/dist/commands.js
+++ b/dist/commands.js
@@ -1,28 +1,27 @@
 import DynamicContentCommands from './dynamicContent/dynamicContent.commands';
 export default (editor => {
-  const dynamicContentCmd = new DynamicContentCommands(editor);
-
-  // Launch Dynamic Content popup: new or edit
+  const dynamicContentCmd = new DynamicContentCommands(editor); // Launch Dynamic Content popup: new or edit
   // Once the command is active, it has to be stopped before it can be run again.
+
   editor.Commands.add('preset-mautic:dynamic-content-open', {
     run: (edtr, sender, options = {}) => {
       dynamicContentCmd.showDynamicContentPopup(edtr, sender, options);
     },
     stop: () => dynamicContentCmd.stopDynamicContentPopup()
-  });
-  // Component to {token}
+  }); // Component to {token}
+
   editor.Commands.add('preset-mautic:dynamic-content-components-to-tokens', {
     run: edtr => dynamicContentCmd.convertDynamicContentComponentsToTokens(edtr)
-  });
-  // Link store to Compoennt
+  }); // Link store to Compoennt
+
   editor.Commands.add('preset-mautic:link-component-to-store-item', {
     run: (edtr, sender, options) => dynamicContentCmd.linkComponentToStoreItem(edtr, sender, options)
-  });
-  // Fill the Component with values.
+  }); // Fill the Component with values.
+
   editor.Commands.add('preset-mautic:update-dc-components-from-dc-store', {
     run: () => dynamicContentCmd.updateComponentsFromDcStore()
-  });
-  // Delete store item
+  }); // Delete store item
+
   editor.Commands.add('preset-mautic:dynamic-content-delete-store-item', {
     run: (edtr, sender, options) => dynamicContentCmd.deleteDynamicContentStoreItem(edtr, sender, options)
   });

--- a/dist/components.js
+++ b/dist/components.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-else-return */
-import DynamicContentDomComponents from './dynamicContent/dynamicContent.domcomponents';
+import DynamicContentDomComponents from './dynamicContent/dynamicContent.domcomponents'; // https://grapesjs.com/docs/api/component.html
 
-// https://grapesjs.com/docs/api/component.html
 export default (editor => {
   DynamicContentDomComponents.addDynamicContentType(editor);
 });

--- a/dist/content.service.js
+++ b/dist/content.service.js
@@ -1,22 +1,24 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import Logger from './logger';
 export default class ContentService {
   static isMjmlMode(editor) {
     if (!editor) {
       throw new Error('editor is required.');
     }
+
     return ContentService.getMode(editor) === ContentService.modeEmailMjml;
   }
+
   static getMode(editor) {
     const cfg = editor.getConfig();
+
     if (!cfg.pluginsOpts || !cfg.pluginsOpts.grapesjsmautic || !cfg.pluginsOpts.grapesjsmautic.mode) {
       throw new Error('Wrong Mautic Grapesjs mode');
     }
+
     return cfg.pluginsOpts.grapesjsmautic.mode;
   }
-
   /**
    * Get the current Canvas content as complete HTML document:
    * Combine original doctype, header, editor styles and content
@@ -24,64 +26,68 @@ export default class ContentService {
    * @param {GrapesJs Editor} editor
    * @returns HTMLDocument
    */
+
+
   static getCanvasAsHtmlDocument(editor) {
     const parser = new DOMParser();
-    const logger = new Logger(editor);
+    const logger = new Logger(editor); // get original doctype, header and add it to the html
 
-    // get original doctype, header and add it to the html
     const originalContent = ContentService.getOriginalContentHtml();
     const doctype = ContentService.serializeDoctype(originalContent.doctype);
-
     /**
      * Sanitize the content. This updates the originalContent variable directly
      * (as it's passed by reference), so we don't need to re-assign anything here
      */
+
     Mautic.sanitizeHtmlBeforeSave(mQuery(originalContent));
     const htmlCombined = `${doctype}<html>${editor.getHtml()}<style>${editor.getCss({
       avoidProtected: true
-    })}</style></html>`;
+    })}</style></html>`; // get a DocumentHTML from the string
 
-    // get a DocumentHTML from the string
-    const htmlDocument = parser.parseFromString(htmlCombined, 'text/html');
+    const htmlDocument = parser.parseFromString(htmlCombined, 'text/html'); // if no header is set on the canvas, replace it with existing from theme
 
-    // if no header is set on the canvas, replace it with existing from theme
     if (!htmlDocument.head.innerHTML && originalContent.head.innerHTML) {
       logger.debug('Set head based on the original content', {
         head: originalContent.head.innerHTML
       });
       htmlDocument.head.innerHTML = originalContent.head.innerHTML;
     }
+
     return htmlDocument;
   }
-
   /**
    * Get complete current html. Including doctype and original header.
    * @returns string
    */
+
+
   static getEditorHtmlContent(editor) {
     if (!editor) {
       throw new Error('Editor is required.');
     }
+
     const contentDocument = ContentService.getCanvasAsHtmlDocument(editor);
+
     if (!contentDocument || !contentDocument.body) {
       throw new Error('No html content found');
     }
+
     return ContentService.serializeHtmlDocument(contentDocument);
   }
-
   /**
    * Serialize a DocumentHTML Object to a <html> string
    * @param {DocumentHTML} contentDocument
    */
+
+
   static serializeHtmlDocument(contentDocument) {
     if (!contentDocument || !(contentDocument instanceof HTMLDocument)) {
       throw new Error('No Html Document');
-    }
+    } // @todo add the lang parameter. E.g. <html lang="de-DE">
 
-    // @todo add the lang parameter. E.g. <html lang="de-DE">
+
     return `${ContentService.serializeDoctype(contentDocument.doctype)}<html>${contentDocument.head.outerHTML}${contentDocument.body.outerHTML}</html>`;
   }
-
   /**
    * Returns the correct string for valid (HTML5) doctypes, eg:
    * <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">
@@ -89,40 +95,50 @@ export default class ContentService {
    * @param {DocumentType}
    * @returns string
    */
+
+
   static serializeDoctype(doctype) {
     if (!doctype) {
       return '';
     }
+
     return new XMLSerializer().serializeToString(doctype);
   }
-
   /**
    * Get the selected themes original or the users last saved
    * content from the db. Loaded via Mautic PHP into the textarea.
    * @returns HTMLDocument
    */
+
+
   static getOriginalContentHtml() {
     // Parse HTML theme/template
     const parser = new DOMParser();
     const textareaHtml = mQuery('textarea.builder-html');
     const doc = parser.parseFromString(textareaHtml.val(), 'text/html');
+
     if (!doc.body.innerHTML || !doc.head.innerHTML) {
       throw new Error('No valid HTML template found');
     }
+
     return doc;
   }
-
   /**
    * Extract all stylesheets from the template <head>
    * @todo use DocumentHTML Styles directly
    */
+
+
   static getStyles() {
     const content = ContentService.getOriginalContentHtml();
+
     if (!content.head) {
       return [];
     }
+
     const links = content.head.querySelectorAll('link');
     const styles = [];
+
     if (links) {
       links.forEach(link => {
         if (link && link.rel === 'stylesheet') {
@@ -130,9 +146,14 @@ export default class ContentService {
         }
       });
     }
+
     return styles;
   }
+
 }
+
 _defineProperty(ContentService, "modeEmailHtml", 'email-html');
+
 _defineProperty(ContentService, "modeEmailMjml", 'email-mjml');
+
 _defineProperty(ContentService, "modePageHtml", 'page-html');

--- a/dist/dynamicContent/dynamicContent.blocks.js
+++ b/dist/dynamicContent/dynamicContent.blocks.js
@@ -1,15 +1,18 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 export default class DynamicContentBlocks {
   constructor(editor, opts = {}) {
     _defineProperty(this, "editor", void 0);
+
     _defineProperty(this, "opts", void 0);
+
     _defineProperty(this, "blockManager", void 0);
+
     this.editor = editor;
     this.opts = opts;
     this.blockManager = this.editor.BlockManager;
   }
+
   addDynamciContentBlock() {
     this.blockManager.add('dynamic-content', {
       label: Mautic.translate('grapesjsbuilder.dynamicContentBlockLabel'),
@@ -28,4 +31,5 @@ export default class DynamicContentBlocks {
       }
     });
   }
+
 }

--- a/dist/dynamicContent/dynamicContent.blocks.js
+++ b/dist/dynamicContent/dynamicContent.blocks.js
@@ -13,20 +13,17 @@ export default class DynamicContentBlocks {
     this.blockManager = this.editor.BlockManager;
   }
 
-  addDynamciContentBlock() {
+  addDynamicContentBlock() {
     this.blockManager.add('dynamic-content', {
       label: Mautic.translate('grapesjsbuilder.dynamicContentBlockLabel'),
       activate: true,
       select: true,
-      attributes: {
-        class: 'fa fa-tag'
-      },
+      media: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+        <path d="M0 80V229.5c0 17 6.7 33.3 18.7 45.3l176 176c25 25 65.5 25 90.5 0L418.7 317.3c25-25 25-65.5 0-90.5l-176-176c-12-12-28.3-18.7-45.3-18.7H48C21.5 32 0 53.5 0 80zm112 32a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/>
+      </svg>`,
       content: {
         type: 'dynamic-content',
         content: '{dynamiccontent="Dynamic Content"}',
-        style: {
-          padding: '10px'
-        },
         activeOnRender: 1
       }
     });

--- a/dist/dynamicContent/dynamicContent.commands.js
+++ b/dist/dynamicContent/dynamicContent.commands.js
@@ -1,20 +1,23 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import Logger from '../logger';
 import MjmlService from '../mjml/mjml.service';
 import DynamicContentService from './dynamicContent.service';
 export default class DynamicContentCommands {
   constructor(editor) {
     _defineProperty(this, "editor", void 0);
+
     _defineProperty(this, "dcPopup", void 0);
+
     _defineProperty(this, "dcService", void 0);
+
     _defineProperty(this, "logger", void 0);
+
     this.dcService = new DynamicContentService(editor);
     this.logger = new Logger(editor);
-  }
+  } // eslint-disable-next-line class-methods-use-this
 
-  // eslint-disable-next-line class-methods-use-this
+
   stopDynamicContentPopup() {
     // Destroy Dynamic Content editors and write the contents to the textarea
     var logger = this.logger;
@@ -30,14 +33,16 @@ export default class DynamicContentCommands {
         }
       });
     }
+
     this.dcService.updateDcStoreItem();
   }
-
   /**
    * Update and wire all dynamic content components on the canvas to
    * human readable texts/slots/components.
    * E.g. if they are initialized from a {token}
    */
+
+
   updateComponentsFromDcStore() {
     const components = this.dcService.getDcComponents();
     components.forEach(comp => {
@@ -48,7 +53,6 @@ export default class DynamicContentCommands {
       }
     });
   }
-
   /**
    * Convert dynamic content components to tokens
    * Dynamic Content => {dynamicContent}
@@ -57,6 +61,8 @@ export default class DynamicContentCommands {
    * @returns integer nr of dynamic content slots found
    */
   // eslint-disable-next-line class-methods-use-this
+
+
   convertDynamicContentComponentsToTokens(editor) {
     // get all dynamic content elements loaded in the editor
     const dynamicContents = editor.DomComponents.getWrapper().find('[data-slot="dynamicContent"]');
@@ -66,19 +72,20 @@ export default class DynamicContentCommands {
     dynamicContents.forEach(dynamicContent => {
       const attributes = dynamicContent.getAttributes();
       const decId = attributes['data-param-dec-id'];
+
       if (!decId) {
         this.logger.debug('DC: Expected a Dynamic Content component', {
           dynamicContent
         });
         throw new Error('No Dynamic Content component');
       }
+
       const dynConId = DynamicContentCommands.getDcStoreId(attributes['data-param-dec-id']);
       const dynConTarget = mQuery(dynConId);
       const dynConName = dynConTarget.find(`${dynConId}_tokenName`).val();
-      const dynConToken = `{dynamiccontent="${dynConName}"}`;
-
-      // Clear id because it's reloaded by Mautic and this prevent slot to be destroyed by GrapesJs destroy event on close.
+      const dynConToken = `{dynamiccontent="${dynConName}"}`; // Clear id because it's reloaded by Mautic and this prevent slot to be destroyed by GrapesJs destroy event on close.
       // dynamicContent.addAttributes({ 'data-param-dec-id': '' });
+
       this.logger.debug("DC: Replaced component's content with its token", {
         dynamicContent,
         dynConToken
@@ -88,7 +95,6 @@ export default class DynamicContentCommands {
     });
     return dynamicContents.length;
   }
-
   /**
    * Build and display the Dynamic Content editor popup/modal window.
    * Hint: the passed in editor is the main grapesjs editor.
@@ -96,6 +102,8 @@ export default class DynamicContentCommands {
    * @param {Model} component The current grapesjs component
    */
   // eslint-disable-next-line class-methods-use-this
+
+
   showDynamicContentPopup(editor, sender, options) {
     this.dcPopup = DynamicContentCommands.buildDynamicContentPopup();
     this.addDynamicContentEditor(editor, options);
@@ -103,111 +111,116 @@ export default class DynamicContentCommands {
     const modal = editor.Modal;
     modal.setTitle(title);
     editor.Modal.setContent(this.dcPopup);
-    modal.open();
+    modal.open(); // Set up dynamic content editors if present
 
-    // Set up dynamic content editors if present
-    Mautic.setDynamicContentEditors(Mautic.getBuilderContainer());
+    Mautic.setDynamicContentEditors(Mautic.getBuilderContainer()); // When a new Dynamic Content filter (tab) is added, we want to turn the editor into CKEditor.
 
-    // When a new Dynamic Content filter (tab) is added, we want to turn the editor into CKEditor.
     Mautic.dynamicContentAddNewFilterListener(textarea => {
       Mautic.ConvertFieldToCkeditor(textarea, {});
-    });
+    }); // When a new Dynamic Content item (slot) is added, we want to turn the editor into CKEditor.
 
-    // When a new Dynamic Content item (slot) is added, we want to turn the editor into CKEditor.
     Mautic.dynamicContentAddNewItemListener(textarea => {
       Mautic.ConvertFieldToCkeditor(textarea, {});
     });
     modal.onceClose(() => editor.stopCommand('preset-mautic:dynamic-content-open'));
   }
-
   /**
    * Build the basic popup/modal frame to hold the dynamic content editor
    * @returns HTMLDivElement
    */
+
+
   static buildDynamicContentPopup() {
-    const codePopup = document.createElement('div');
-    // codePopup.setAttribute('id', 'codePopup');
+    const codePopup = document.createElement('div'); // codePopup.setAttribute('id', 'codePopup');
+
     codePopup.setAttribute('id', 'dynamic-content-popup');
     return codePopup;
   }
-
   /**
    * Load Dynamic Content editor and append to the codePopup Modal
    */
+
+
   addDynamicContentEditor(editor, options) {
     const {
       target
     } = options;
     const dcComponent = target || editor.getSelected();
+
     if (!dcComponent) {
       throw new Error('No DC Components found');
     }
-    const attributes = dcComponent.getAttributes();
-    // const popupContent = dcPopup.querySelector('#dynamic-content-popup');
 
+    const attributes = dcComponent.getAttributes(); // const popupContent = dcPopup.querySelector('#dynamic-content-popup');
     // do we need both?
     // console.warn({ dcPopup });
     // console.warn({ popupContent });
-
     // get the dynamic content editor
+
     const dcEditor = mQuery(DynamicContentCommands.getDcStoreId(attributes['data-param-dec-id']));
+
     if (dcEditor.length <= 0) {
       throw new Error(`No Dynamic Content editor found for decId: '${attributes['data-param-dec-id']}'`);
-    }
+    } // Show if hidden
 
-    // Show if hidden
-    dcEditor.removeClass('fade');
-    // Hide delete default button
-    dcEditor.find('.tab-pane:first').find('.remove-item').hide();
 
-    // Clean existing editor
-    mQuery(this.dcPopup).empty();
-    // Insert inside popup
+    dcEditor.removeClass('fade'); // Hide delete default button
+
+    dcEditor.find('.tab-pane:first').find('.remove-item').hide(); // Clean existing editor
+
+    mQuery(this.dcPopup).empty(); // Insert inside popup
+
     mQuery(this.dcPopup).append(dcEditor.detach());
   }
+
   linkComponentToStoreItem(edtr, sender, options) {
     // Add a new DC HTML store item, if it doesnt exist.
     // Hint: the first dynamic content item (tab) is created from php: #emailform_dynamicContent_0
     this.dcService.linkComponentToStoreItem(options.component);
   }
-
   /**
    * Delete DynamicContent on Mautic side
    *
    * @param component
    */
   // eslint-disable-next-line class-methods-use-this
+
+
   deleteDynamicContentStoreItem(editor, sender, options) {
     const {
       component
     } = options;
     const attributes = component.getAttributes();
+
     if (!attributes['data-param-dec-id']) {
       this.logger.warning('no dec-id found. Can not delete', attributes);
     }
+
     const dcStoreId = DynamicContentCommands.getDcStoreId(attributes['data-param-dec-id']);
     const dcStoreItem = mQuery(dcStoreId);
+
     if (!dcStoreItem) {
       this.logger.warning('No DynamicContent store item found', {
         dcStoreId
       });
-    }
+    } // remove the store item
 
-    // remove the store item
-    dcStoreItem.find('a.remove-item:first').click();
-    // remove store navigation item
+
+    dcStoreItem.find('a.remove-item:first').click(); // remove store navigation item
+
     const dynCon = mQuery('.dynamicContentFilterContainer').find(`a[href='${dcStoreId}']`);
+
     if (!dynCon || !dynCon.parent()) {
       this.logger.warning('No DynamicContent store item to delete found', {
         dcStoreId
       });
     }
+
     dynCon.parent().remove();
     this.logger.debug('DC: DynamicContent store item removed', {
       dcStoreId
     });
   }
-
   /**
    * Get the DynamicContent identifier of the html store item
    * based on the token nr (decId)
@@ -215,11 +228,16 @@ export default class DynamicContentCommands {
    * @param {integer} decId
    * @returns string
    */
+
+
   static getDcStoreId(decId) {
     const id = decId - 1;
+
     if (id < 0) {
       throw new Error('no dynamic content ID');
     }
+
     return `#emailform_dynamicContent_${id}`;
   }
+
 }

--- a/dist/dynamicContent/dynamicContent.commands.js
+++ b/dist/dynamicContent/dynamicContent.commands.js
@@ -20,15 +20,18 @@ export default class DynamicContentCommands {
 
   stopDynamicContentPopup() {
     // Destroy Dynamic Content editors and write the contents to the textarea
-    var logger = this.logger;
+    // eslint-disable-next-line prefer-destructuring
+    const logger = this.logger; // eslint-disable-next-line no-undef
 
-    if (ckEditors != undefined && ckEditors.size > 0) {
-      ckEditors.forEach(function (value, key, map) {
+    if (typeof ckEditors !== 'undefined' && ckEditors.size > 0) {
+      // eslint-disable-next-line no-undef
+      ckEditors.forEach((value, key, map) => {
         const name = key.id;
 
         if (name.includes('dynamicContent')) {
           logger.debug(`Destroying Dynamic Content editor: ${name}`);
-          map.get(key).destroy();
+          map.get(key).destroy(); // eslint-disable-next-line no-undef
+
           ckEditors.delete(key);
         }
       });

--- a/dist/dynamicContent/dynamicContent.domcomponents.js
+++ b/dist/dynamicContent/dynamicContent.domcomponents.js
@@ -31,8 +31,8 @@ export default class DynamicContentDomComponents {
       },
 
       /**
-        * Initilize the component
-        */
+       * Initilize the component
+       */
       init() {
         // link component to the corresponding html store item
         this.em.get('Commands').run('preset-mautic:link-component-to-store-item', {

--- a/dist/dynamicContent/dynamicContent.domcomponents.js
+++ b/dist/dynamicContent/dynamicContent.domcomponents.js
@@ -1,21 +1,20 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import ContentService from '../content.service';
 import DynamicContentService from './dynamicContent.service';
 export default class DynamicContentDomComponents {
   constructor() {
     _defineProperty(this, "dcService", void 0);
   }
+
   static addDynamicContentType(editor) {
     const dc = editor.DomComponents;
     const baseTypeName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'text';
     const tagName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'div';
     const baseType = dc.getType(baseTypeName);
     const baseModel = baseType.model;
-    const model = baseModel.extend({
+    const model = {
       defaults: {
-        ...baseModel.prototype.defaults,
         name: 'Dynamic Content',
         tagName,
         draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
@@ -27,21 +26,22 @@ export default class DynamicContentDomComponents {
           'data-gjs-type': 'dynamic-content',
           // Type for GrapesJS
           'data-slot': 'dynamicContent' // used to find the DC component on the canvas for e.g. token transformation
+
         }
       },
 
       /**
-       * Initilize the component
-       */
+        * Initilize the component
+        */
       init() {
         // link component to the corresponding html store item
         this.em.get('Commands').run('preset-mautic:link-component-to-store-item', {
           component: this
-        });
+        }); // Add toolbar edit button if it's not already in
 
-        // Add toolbar edit button if it's not already in
         const toolbar = this.get('toolbar');
         const id = 'toolbar-dynamic-content';
+
         if (!toolbar.filter(tlb => tlb.id === id).length) {
           toolbar.unshift({
             id,
@@ -51,7 +51,8 @@ export default class DynamicContentDomComponents {
             }
           });
         }
-      }
+      },
+
       // @todo: show the store items default content on the canvas
       // updated(property, value, prevValue) {
       //   console.log('Local hook: model.updated', {
@@ -60,7 +61,6 @@ export default class DynamicContentDomComponents {
       //     prevValue,
       //   });
       // },
-    }, {
       // Dynamic Content component detection
       isComponent(el) {
         if (el.getAttribute && el.getAttribute('data-slot') === 'dynamicContent') {
@@ -68,16 +68,19 @@ export default class DynamicContentDomComponents {
             type: 'dynamic-content'
           };
         }
+
         return false;
       }
-    });
-    const view = baseType.view.extend({
+
+    };
+    const view = {
       attributes: {
         style: 'pointer-events: all; display: table; width: 100%;user-select: none;'
       },
       events: {
         dblclick: 'onActive'
       },
+
       // replace token with human readable view
       onRender(el) {
         const dcService = new DynamicContentService(editor);
@@ -86,15 +89,15 @@ export default class DynamicContentDomComponents {
         this.el.innerHTML = dcItem.content;
         dcService.logger.debug('DC: Updated view', dcItem);
       },
+
       // open the dynamic content modal if the editor is added or double clicked
       onActive() {
-        const target = this.model;
-        // open the editor in the popup
+        const target = this.model; // open the editor in the popup
+
         this.em.get('Commands').run('preset-mautic:dynamic-content-open', {
           target
         });
-      }
-      // does not work: gets removed when Sorting (by grapesjs)
+      } // does not work: gets removed when Sorting (by grapesjs)
       // removed() {
       //   // Delete dynamic-content on Mautic side
       //   const component = this.model;
@@ -102,12 +105,14 @@ export default class DynamicContentDomComponents {
       //     .get('Commands')
       //     .run('preset-mautic:dynamic-content-delete-store-item', { component });
       // },
-    });
 
-    // add the Dynamic Content component
+
+    }; // add the Dynamic Content component
+
     dc.addType('dynamic-content', {
       model,
       view
     });
   }
+
 }

--- a/dist/dynamicContent/dynamicContent.domcomponents.js
+++ b/dist/dynamicContent/dynamicContent.domcomponents.js
@@ -13,21 +13,29 @@ export default class DynamicContentDomComponents {
     const tagName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'div';
     const baseType = dc.getType(baseTypeName);
     const baseModel = baseType.model;
-    const model = {
-      defaults: {
-        name: 'Dynamic Content',
-        tagName,
-        draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
-        droppable: false,
-        editable: false,
-        stylable: false,
-        propagate: ['droppable', 'editable'],
-        attributes: {
-          'data-gjs-type': 'dynamic-content',
-          // Type for GrapesJS
-          'data-slot': 'dynamicContent' // used to find the DC component on the canvas for e.g. token transformation
-
+    const dynamicContentModel = {
+      name: 'Dynamic Content',
+      tagName,
+      draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
+      droppable: false,
+      editable: false,
+      stylable: false,
+      propagate: ['droppable', 'editable'],
+      style: { ...baseModel.prototype.defaults['style-default'],
+        ...{
+          display: 'block'
         }
+      },
+      attributes: {
+        'data-gjs-type': 'dynamic-content',
+        // Type for GrapesJS
+        'data-slot': 'dynamicContent' // used to find the DC component on the canvas for e.g. token transformation
+
+      }
+    };
+    const model = {
+      defaults: { ...baseModel.prototype.defaults,
+        ...dynamicContentModel
       },
 
       /**
@@ -51,26 +59,23 @@ export default class DynamicContentDomComponents {
             }
           });
         }
-      },
-
-      // @todo: show the store items default content on the canvas
+      } // @todo: show the store items default content on the canvas
       // updated(property, value, prevValue) {
-      //   console.log('Local hook: model.updated', {
+      //   console.debug('Local hook: model.updated', {
       //     property,
       //     value,
       //     prevValue,
       //   });
       // },
-      // Dynamic Content component detection
-      isComponent(el) {
-        if (el.getAttribute && el.getAttribute('data-slot') === 'dynamicContent') {
-          return {
-            type: 'dynamic-content'
-          };
-        }
+      // does not work: gets removed when Sorting (by grapesjs)
+      // removed() {
+      //   // Delete dynamic-content on Mautic side
+      //   const component = this.model;
+      //   this.em
+      //     .get('Commands')
+      //     .run('preset-mautic:dynamic-content-delete-store-item', { component });
+      // },
 
-        return false;
-      }
 
     };
     const view = {
@@ -82,12 +87,19 @@ export default class DynamicContentDomComponents {
       },
 
       // replace token with human readable view
-      onRender(el) {
+      // eslint-disable-next-line no-shadow
+      onRender({
+        editor,
+        model
+      }) {
         const dcService = new DynamicContentService(editor);
-        const decId = DynamicContentService.getDataParamDecid(el.model);
+        const decId = DynamicContentService.getDataParamDecid(model);
         const dcItem = dcService.getStoreItem(decId);
-        this.el.innerHTML = dcItem.content;
-        dcService.logger.debug('DC: Updated view', dcItem);
+
+        if (typeof dcItem !== 'undefined') {
+          this.el.innerHTML = dcItem.content;
+          dcService.logger.debug('DC: Updated view', dcItem);
+        }
       },
 
       // open the dynamic content modal if the editor is added or double clicked
@@ -97,19 +109,21 @@ export default class DynamicContentDomComponents {
         this.em.get('Commands').run('preset-mautic:dynamic-content-open', {
           target
         });
-      } // does not work: gets removed when Sorting (by grapesjs)
-      // removed() {
-      //   // Delete dynamic-content on Mautic side
-      //   const component = this.model;
-      //   this.em
-      //     .get('Commands')
-      //     .run('preset-mautic:dynamic-content-delete-store-item', { component });
-      // },
-
+      }
 
     }; // add the Dynamic Content component
 
     dc.addType('dynamic-content', {
+      // Dynamic Content component detection
+      isComponent: el => {
+        if (typeof el.getAttribute !== 'undefined' && el.getAttribute('data-slot') === 'dynamicContent') {
+          return {
+            type: 'dynamic-content'
+          };
+        }
+
+        return false;
+      },
       model,
       view
     });

--- a/dist/dynamicContent/dynamicContent.events.js
+++ b/dist/dynamicContent/dynamicContent.events.js
@@ -1,19 +1,20 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import DynamicContentCommands from './dynamicContent.commands';
 import DynamicContentService from './dynamicContent.service';
 export default class DynamicContentEvents {
   constructor(editor) {
     _defineProperty(this, "editor", void 0);
+
     _defineProperty(this, "dcService", void 0);
+
     this.editor = editor;
     this.dcService = new DynamicContentService(this.editor);
     this.dccmd = new DynamicContentCommands(this.editor);
-  }
-
-  // @todo merge events and listeners. or move this to the component itself as a
+  } // @todo merge events and listeners. or move this to the component itself as a
   // local listener. see create-new-dynamic-content-store-item
+
+
   onComponentRemove() {
     this.editor.on('component:remove', component => {
       // Delete dynamic-content on Mautic side
@@ -24,4 +25,5 @@ export default class DynamicContentEvents {
       }
     });
   }
+
 }

--- a/dist/dynamicContent/dynamicContent.events.js
+++ b/dist/dynamicContent/dynamicContent.events.js
@@ -18,7 +18,7 @@ export default class DynamicContentEvents {
   onComponentRemove() {
     this.editor.on('component:remove', component => {
       // Delete dynamic-content on Mautic side
-      if (component.get('type') === 'dynamic-content') {
+      if (component === this.editor.getSelected() && component.get('type') === 'dynamic-content') {
         this.editor.runCommand('preset-mautic:dynamic-content-delete-store-item', {
           component
         });

--- a/dist/dynamicContent/dynamicContent.service.js
+++ b/dist/dynamicContent/dynamicContent.service.js
@@ -1,6 +1,5 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 import Logger from '../logger';
 export default class DynamicContentService {
   /**
@@ -12,15 +11,16 @@ export default class DynamicContentService {
   /**
    * Components currently on the canvas/editor
    */
-
   constructor(editor) {
     _defineProperty(this, "dcStoreItems", []);
+
     _defineProperty(this, "dcComponents", []);
+
     _defineProperty(this, "editor", void 0);
+
     this.logger = new Logger(editor);
     this.editor = editor;
   }
-
   /**
    * Get the name of the dynamic content element.
    * Used as identifier
@@ -28,74 +28,85 @@ export default class DynamicContentService {
    * @param {GrapesJS Component} component
    * @returns string | null
    */
+
+
   getTokenName(component) {
     const regex = RegExp(/\{dynamiccontent="(.*)"\}/, 'g');
     const content = component.get('content');
     const regexEx = regex.exec(content);
+
     if (!regexEx || !regexEx[1]) {
       this.logger.debug('DC: No dynamic content tokens to get', {
         content
       });
       return null;
     }
+
     return regexEx[1];
   }
-
   /**
    * Get dec ID from the store items identifier: e.g. #emailform_dynamicContent_1
    * @returns integer
    */
+
+
   static getDecId(storeItemIdentifier) {
     // dec id starts with 1, so we add +1
     const decId = parseInt(storeItemIdentifier.replace(/[^0-9]/g, ''), 10) + 1;
+
     if (decId <= 0) {
       throw new Error('DC: no valid decId');
     }
+
     return decId;
   }
-
   /**
    * Returns the decId from the component
    * @returns integer
    */
+
+
   static getDataParamDecid(component) {
     return parseInt(component.getAttributes()['data-param-dec-id'], 10) || 0;
   }
-
   /**
    * Link the component on the canvas with the item in the HTML store
    * If it does not exist, create a new store item
    */
+
+
   linkComponentToStoreItem(component) {
     // get components data-param-dec-id (can come from token from db)
     let decId = DynamicContentService.getDataParamDecid(component);
+
     if (decId > 0) {
       this.logger.debug('DC: Already wired up', {
         decId
       });
       return decId;
-    }
-    // not wired up yet - get component token id
+    } // not wired up yet - get component token id
+
+
     const tokenName = this.getTokenName(component);
     const tokenNr = DynamicContentService.getDecId(tokenName);
     decId = tokenNr;
+
     if (decId > 0) {
       this.logger.debug('DC: Using decId from token nr', {
         tokenName,
         decId
       });
       return decId;
-    }
+    } // double check if a store item exists - if not found - create new store item
 
-    // double check if a store item exists - if not found - create new store item
+
     if (!this.getStoreItem(decId)) {
       this.createNewStoreItem(component);
-    }
+    } // return components dec-id (also from the new one)
 
-    // return components dec-id (also from the new one)
+
     return DynamicContentService.getDataParamDecid(component);
   }
-
   /**
    * Get the content from the Html store and put the default content on the canvas.
    * Creates a store item (filter) in Mautic Form if new.
@@ -104,32 +115,34 @@ export default class DynamicContentService {
    *
    * @param {GrapesJS Component} component
    */
+
+
   updateComponentFromDcStore(component) {
     // get the item/tab matching the dynamic content on the canvas
     let dataParamDecId = DynamicContentService.getDataParamDecid(component);
-    let dcItem = this.getStoreItem(dataParamDecId);
+    let dcItem = this.getStoreItem(dataParamDecId); // Load the html store item
 
-    // Load the html store item
     dataParamDecId = DynamicContentService.getDataParamDecid(component);
-    dcItem = this.getStoreItem(dataParamDecId);
+    dcItem = this.getStoreItem(dataParamDecId); // Update the Grapesjs component with the content from the HTML store item
 
-    // Update the Grapesjs component with the content from the HTML store item
     this.updateComponent(component, dcItem);
     return true;
   }
-
   /**
    * if the editors modal is closed/stopped the Components content visible
    * on the canvas and the html store item has to be updated
    */
+
+
   updateDcStoreItem() {
     // For the editing inside grapesjs the dynamcicontent popup is moved to the "grapesjs dom"
     // so it has to be moved back to the Mautic email form for saving.
-    const modalContent = mQuery('#dynamic-content-popup');
-    // On modal close -> move editor within Mautic
+    const modalContent = mQuery('#dynamic-content-popup'); // On modal close -> move editor within Mautic
+
     if (!modalContent) {
       throw new Error('DC: No dynamic content popup found');
     }
+
     const dynamicContentContainer = mQuery('#dynamicContentContainer');
     const content = mQuery(modalContent).contents().first();
     dynamicContentContainer.append(content);
@@ -139,37 +152,38 @@ export default class DynamicContentService {
       id: content.attr('id')
     });
   }
-
   /**
    * Get a dynamic content item from its html store
    */
+
+
   getStoreItem(decId) {
     // get all items
     this.getDcStoreItems();
     const item = this.dcStoreItems.find(itm => itm.decId === decId);
     return item;
   }
-
   /**
    * Set the html/content of the visible component on the canvas
    */
+
+
   updateComponent(component, dcItem) {
     if (!component || !dcItem) {
       throw new Error('No component or dynamic content item');
     }
+
     this.logger.debug('DC: Updating DC component with values from store', {
       dcItem
-    });
-    // Update the component on the canvas with new values from the html store
+    }); // Update the component on the canvas with new values from the html store
     // and link it  with the id to the html store
     // needed for new components
+
     component.addAttributes({
       'data-param-dec-id': dcItem.decId
     });
     component.set('content', dcItem.content);
-    return component;
-
-    // gets the default content to be displayed on the canvas. Should have been replaced by the `dcItem.content`
+    return component; // gets the default content to be displayed on the canvas. Should have been replaced by the `dcItem.content`
     // let dynConContent = '';
     // if (dcItem.decId) {
     //   const dynConContainer = mQuery(dcTarget.htmlId).find(dcTarget.content);
@@ -181,7 +195,6 @@ export default class DynamicContentService {
     //   }
     // }
   }
-
   /**
    * If dynamic content item in html store doesn't exist -> create
    * @todo replace mQuery('#dynamicContentTabs') with class property
@@ -189,14 +202,15 @@ export default class DynamicContentService {
    * @param {GrapesJS Component} component
    * @param {string}
    */
+
+
   createNewStoreItem(component) {
     const storeItemIdentifier = Mautic.createNewDynamicContentItem(mQuery);
     const decId = DynamicContentService.getDecId(storeItemIdentifier);
     component.addAttributes({
       'data-param-dec-id': decId
-    });
+    }); // Replace token on canvas with user facing name: dcName
 
-    // Replace token on canvas with user facing name: dcName
     component.set('content', `Dynamic Content ${decId}`);
     this.logger.debug('DC: Created a new Dynamic Content item in store', {
       decId,
@@ -204,7 +218,6 @@ export default class DynamicContentService {
     });
     return component;
   }
-
   /**
    * Extract the dynamic content index and the html id from a string:
    * e.g. href from dcTarget
@@ -213,22 +226,25 @@ export default class DynamicContentService {
    *
    * @param {string} identifier e.g. http://localhost:1234/#emailform_dynamicContent_1
    */
+
+
   static getDcTarget(identifier) {
     const regex = RegExp(/(#emailform_dynamicContent_)(\d*)/, 'g');
     const result = regex.exec(identifier);
+
     if (!result || result.length !== 3) {
       throw new Error(`No DynamicContent target found: ${identifier}`);
     }
+
     return {
       htmlId: `${result[1]}${result[2]}`,
       // #emailform_dynamicContent_1
       decId: parseInt(result[2], 10) + 1,
       // 2
       content: `${result[1]}${result[2]}_content` // #emailform_dynamicContent_1_content
-    };
-  }
 
-  // /**
+    };
+  } // /**
   //  * Extract the dynamic content id from an id string:
   //  *
   //  * @param {string} identifier e.g. emailform_dynamicContent_1
@@ -249,27 +265,30 @@ export default class DynamicContentService {
    * @param {string} id id of the input field
    * @returns string of the field
    */
+
+
   static getDcName(target) {
     return `Dynamic Content ${target.decId}`;
   }
-
   /**
    * Get the default content
    * @param {string} id id of the textarea
    * @returns string with the html in the textarea
    */
+
+
   static getDcContent(target) {
     return mQuery(target.id).val() || DynamicContentService.getDcName(target);
   }
-
   /**
    * Get all Dynamic Content items from the HTML store
    * @returns array of objects with title and href
    */
-  getDcStoreItems() {
-    this.dcStoreItems = [];
 
-    // #dynamicContentContainer
+
+  getDcStoreItems() {
+    this.dcStoreItems = []; // #dynamicContentContainer
+
     mQuery('.dynamic-content').each((index, value) => {
       const dcTarget = DynamicContentService.getDcTarget(`#${value.id}`);
       this.dcStoreItems.push({
@@ -280,24 +299,26 @@ export default class DynamicContentService {
         name: DynamicContentService.getDcName(dcTarget),
         // Dynamic Content 1
         content: DynamicContentService.getDcContent(dcTarget) // Default Dynamic Content
-      });
-    });
 
-    // one is always set from php
+      });
+    }); // one is always set from php
+
     if (!this.dcStoreItems[0]) {
       throw Error('No dynamic content store item found!');
     }
   }
-
   /**
    * Get all the dynamic content components currently
    * on the canvas (in the editor).
    * @return {GrapesJS Component} array
    */
+
+
   getDcComponents() {
     if (!this.editor) {
       throw new Error('no Editor');
     }
+
     this.dcComponents = [];
     const wrapper = this.editor.getWrapper();
     const dcCompoments = wrapper.find('[data-gjs-type="dynamic-content"]');
@@ -305,8 +326,10 @@ export default class DynamicContentService {
       if (!comp.is('dynamic-content')) {
         throw new Error('no dynamic-content component');
       }
+
       this.dcComponents.push(comp);
     });
     return this.dcComponents;
   }
+
 }

--- a/dist/editorFonts/editorFonts.service.js
+++ b/dist/editorFonts/editorFonts.service.js
@@ -2,23 +2,28 @@ import ContentService from '../content.service';
 export default class EditorFontsService {
   static loadEditorFonts(editor) {
     const styleManager = editor.StyleManager;
+
     if (!styleManager) {
       // eslint-disable-next-line no-console
       console.error('No GrapesJS Style Manager found.');
       return;
     }
+
     const fontProperty = styleManager.getProperty('typography', 'font-family');
+
     if (!fontProperty) {
       // eslint-disable-next-line no-console
       console.error('No font properties found in the typography sector.');
       return;
     }
+
     const fontList = fontProperty.get('list');
     EditorFontsService.updateFontList(editor, fontList);
     EditorFontsService.sortFontList(fontList);
     fontProperty.set('list', fontList);
     styleManager.render();
   }
+
   static updateFontList(editor, fontList) {
     const canvasHead = editor.Canvas.getDocument().head;
     mauticEditorFonts.forEach(item => {
@@ -27,6 +32,7 @@ export default class EditorFontsService {
           value: item.font,
           name: item.name
         });
+
         if (item.url && canvasHead) {
           EditorFontsService.appendFontStyleLink(canvasHead, item.url);
         }
@@ -34,10 +40,12 @@ export default class EditorFontsService {
     });
     return fontList;
   }
+
   static sortFontList(fontList) {
     fontList.sort((a, b) => a.name < b.name ? -1 : 1);
     return fontList;
   }
+
   static addFontLinksToHtml(htmlCode) {
     const htmlDoc = new DOMParser().parseFromString(htmlCode, 'text/html');
     const headElem = htmlDoc.head;
@@ -53,10 +61,12 @@ export default class EditorFontsService {
     });
     return ContentService.serializeHtmlDocument(htmlDoc);
   }
+
   static appendFontStyleLink(head, url) {
     const linkElem = EditorFontsService.createStylesheetLink(url);
     return head.appendChild(linkElem);
   }
+
   static createStylesheetLink(url) {
     const linkElem = document.createElement('link');
     linkElem.rel = 'stylesheet';
@@ -64,4 +74,5 @@ export default class EditorFontsService {
     linkElem.href = url;
     return linkElem;
   }
+
 }

--- a/dist/editorFonts/editorFonts.service.js
+++ b/dist/editorFonts/editorFonts.service.js
@@ -35,7 +35,10 @@ export default class EditorFontsService {
   static updateFontList(editor, fontList, propertyType) {
     const canvasHead = editor.Canvas.getDocument().head;
     mauticEditorFonts.forEach(item => {
-      if (!fontList.find(element => element.name === item.name)) {
+      let key = 'name';
+      if (propertyType === 'options') key = 'label';
+
+      if (!fontList.find(element => element[key] === item.name)) {
         if (propertyType === 'list') fontList.push({
           value: item.font,
           name: item.name

--- a/dist/editorFonts/editorFonts.service.js
+++ b/dist/editorFonts/editorFonts.service.js
@@ -15,22 +15,34 @@ export default class EditorFontsService {
       // eslint-disable-next-line no-console
       console.error('No font properties found in the typography sector.');
       return;
+    } // first check if we have the 'list' property to work with
+
+
+    let propertyType = 'list';
+    let fontList = fontProperty.get('list'); // use 'options' if 'list' doesn't exist
+
+    if (typeof fontList === 'undefined') {
+      propertyType = 'options';
+      fontList = fontProperty.get('options');
     }
 
-    const fontList = fontProperty.get('list');
-    EditorFontsService.updateFontList(editor, fontList);
-    EditorFontsService.sortFontList(fontList);
-    fontProperty.set('list', fontList);
+    EditorFontsService.updateFontList(editor, fontList, propertyType);
+    EditorFontsService.sortFontList(fontList, propertyType);
+    fontProperty.set(propertyType, fontList);
     styleManager.render();
   }
 
-  static updateFontList(editor, fontList) {
+  static updateFontList(editor, fontList, propertyType) {
     const canvasHead = editor.Canvas.getDocument().head;
     mauticEditorFonts.forEach(item => {
       if (!fontList.find(element => element.name === item.name)) {
-        fontList.push({
+        if (propertyType === 'list') fontList.push({
           value: item.font,
           name: item.name
+        });
+        if (propertyType === 'options') fontList.push({
+          id: item.font,
+          label: item.name
         });
 
         if (item.url && canvasHead) {
@@ -41,8 +53,9 @@ export default class EditorFontsService {
     return fontList;
   }
 
-  static sortFontList(fontList) {
-    fontList.sort((a, b) => a.name < b.name ? -1 : 1);
+  static sortFontList(fontList, propertyType) {
+    if (propertyType === 'list') fontList.sort((a, b) => a.name < b.name ? -1 : 1);
+    if (propertyType === 'options') fontList.sort((a, b) => a.label < b.label ? -1 : 1);
     return fontList;
   }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -14,9 +14,8 @@ export default ((editor, opts = {}) => {
     ...opts
   };
   const logger = new Logger(editor);
-  logger.addListener(config.logFilter, editor);
+  logger.addListener(config.logFilter, editor); // Extend the original `image` and add a confirm dialog before removing it
 
-  // Extend the original `image` and add a confirm dialog before removing it
   am.addType('image', {
     // As you adding on top of an already defined type you can avoid indicating
     // `am.getType('image').view.extend({...` the editor will do it by default
@@ -28,17 +27,16 @@ export default ((editor, opts = {}) => {
         e.stopImmediatePropagation();
         const {
           model
-        } = this;
+        } = this; // eslint-disable-next-line no-alert, no-restricted-globals
 
-        // eslint-disable-next-line no-alert, no-restricted-globals
         if (confirm(Mautic.translate('grapesjsbuilder.deleteAssetConfirmText'))) {
           model.collection.remove(model);
         }
       }
-    }
-  });
 
-  // Load other parts
+    }
+  }); // Load other parts
+
   loadCommands(editor, config);
   loadComponents(editor, config);
   loadEvents(editor, config);

--- a/dist/listeners.js
+++ b/dist/listeners.js
@@ -1,5 +1,4 @@
-export default (() => {
-  // @todo is this needed? why do we copy the original content?
+export default (() => {// @todo is this needed? why do we copy the original content?
   // this.editor.on('run:mautic-editor-email-mjml-close:before', () => {
   //   mQuery('textarea.builder-html').val(this.getBody());
   // });

--- a/dist/logger.js
+++ b/dist/logger.js
@@ -1,36 +1,41 @@
-function _defineProperty(obj, key, value) { key = _toPropertyKey(key); if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
-function _toPropertyKey(arg) { var key = _toPrimitive(arg, "string"); return typeof key === "symbol" ? key : String(key); }
-function _toPrimitive(input, hint) { if (typeof input !== "object" || input === null) return input; var prim = input[Symbol.toPrimitive]; if (prim !== undefined) { var res = prim.call(input, hint || "default"); if (typeof res !== "object") return res; throw new TypeError("@@toPrimitive must return a primitive value."); } return (hint === "string" ? String : Number)(input); }
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
 export default class Logger {
   constructor(editor) {
     _defineProperty(this, "editor", void 0);
+
     if (!editor) {
       throw new Error('Editor is required');
     }
+
     this.editor = editor;
   }
+
   debug(msg, params = {}) {
     this.log(msg, params, 'debug');
   }
+
   info(msg, params = {}) {
     this.log(msg, params, 'info');
   }
+
   warning(msg, params = {}) {
     this.log(msg, params, 'warning');
   }
+
   error(msg, params = {}) {
     this.log(msg, params, 'error');
   }
-
   /**
    *
    * @param {string} msg log message
    * @param {object} params optional params
    * @param {string} level  log level
    */
+
+
   log(msg, params, level = 'debug') {
-    const options = {
-      ...{
+    const options = { ...{
         ns: Logger.namespace,
         level
       },
@@ -38,18 +43,17 @@ export default class Logger {
     };
     this.editor.log(msg, options);
   }
-
   /**
    * What kind of logs to display
    * @param {string} filter `log`, `log:info`, `grapesjs-preset`, `grapesjs-preset:info`
    */
+
+
   addListener(filter = 'log:debug') {
     // find the severity for debug, info, warning.
-    const displaySeverity = Logger.filters.findIndex(element => element === filter);
+    const displaySeverity = Logger.filters.findIndex(element => element === filter); // severity only works with items in Logger.filters. All other filters are applied directly
 
-    // severity only works with items in Logger.filters. All other filters are applied directly
-    if (displaySeverity === -1) {
-      // this.editor.on(filter, (msg, opts) => console.info(msg, opts));
+    if (displaySeverity === -1) {// this.editor.on(filter, (msg, opts) => console.info(msg, opts));
     } else {
       // listen for all logs with a severity > than the current setting.
       Logger.filters.forEach((item, severity) => {
@@ -60,6 +64,9 @@ export default class Logger {
       });
     }
   }
+
 }
+
 _defineProperty(Logger, "namespace", 'grapesjs-preset');
+
 _defineProperty(Logger, "filters", ['log:debug', 'log:info', 'log:warning']);

--- a/dist/mjml/mjml.service.js
+++ b/dist/mjml/mjml.service.js
@@ -8,12 +8,13 @@ export default class MjmlService {
   static getOriginalContentMjml() {
     return mQuery('textarea.builder-mjml').val();
   }
-
   /**
    * Get the editors mjml and transform it to html
    * @param {Grapesjs Editor} editor
    * @returns string
    */
+
+
   static getEditorHtmlContent(editor) {
     // Try catch for mjml parser error
     try {
@@ -26,32 +27,37 @@ export default class MjmlService {
       console.warn(error.message);
       alert('Errors inside your template. Template will not be saved.');
     }
+
     return '';
   }
-
   /**
    * Get the editors mjml
    * @param {Grapesjs Editor} editor
    * @returns string
    */
+
+
   static getEditorMjmlContent(editor) {
     // cleanId: Remove unnecessary IDs (eg. those created automatically)
     return editor.getHtml({
       cleanId: true
     }).trim();
   }
-
   /**
    * Transform MJML to HTML
    * @todo show validation errors in the UI
    * @returns string
    */
+
+
   static mjmlToHtml(mjml, endpoint = '') {
     let html = '';
+
     try {
       if (typeof mjml !== 'string' || !mjml.includes('<mjml>')) {
         throw new Error('No valid MJML provided');
       }
+
       if (endpoint !== '') {
         html = MjmlService.mjmlToHtmlViaEndpoint(mjml, endpoint);
       } else {
@@ -65,13 +71,15 @@ export default class MjmlService {
     } catch (error) {
       console.warn(error);
     }
+
     return html;
   }
-
   /**
    * Transform MJML to HTML via endpoint
    * @returns string
    */
+
+
   static mjmlToHtmlViaEndpoint(mjml, endpoint) {
     const xmlHttpRequest = new XMLHttpRequest();
     xmlHttpRequest.open('POST', endpoint, false);
@@ -81,4 +89,5 @@ export default class MjmlService {
     }));
     return xmlHttpRequest.responseText ? JSON.parse(xmlHttpRequest.responseText) : '';
   }
+
 }

--- a/dist/panels/panels.mjml.js
+++ b/dist/panels/panels.mjml.js
@@ -1,0 +1,57 @@
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+export default class PanelsMjml {
+  constructor(editor) {
+    _defineProperty(this, "panelManager", void 0);
+
+    _defineProperty(this, "editor", void 0);
+
+    this.editor = editor;
+    this.panelManager = editor.Panels;
+  }
+
+  restylePanels() {
+    const iconStyle = 'style="display: block; max-width: 22px"';
+
+    if (typeof this.panelManager.getButton('views', 'open-blocks') !== 'undefined') {
+      this.panelManager.getButton('views', 'open-blocks').set({
+        className: '',
+        // resets the custom classes, so only displays the default ones and we don't render the icon font anymore
+        label: `<svg ${iconStyle} viewBox="0 0 24 24">
+          <path fill="currentColor" d="M17,13H13V17H11V13H7V11H11V7H13V11H17M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z" />
+        </svg>`
+      });
+    }
+
+    if (typeof this.panelManager.getButton('views', 'open-sm') !== 'undefined') {
+      this.panelManager.getButton('views', 'open-sm').set({
+        className: '',
+        // resets the custom classes, so only displays the default ones and we don't render the icon font anymore
+        label: `<svg style="display: block; max-width: 22px" viewBox="0 0 24 24">
+          <path fill="currentColor" d="M20.71,4.63L19.37,3.29C19,2.9 18.35,2.9 17.96,3.29L9,12.25L11.75,15L20.71,6.04C21.1,5.65 21.1,5 20.71,4.63M7,14A3,3 0 0,0 4,17C4,18.31 2.84,19 2,19C2.92,20.22 4.5,21 6,21A4,4 0 0,0 10,17A3,3 0 0,0 7,14Z" />
+        </svg>`
+      });
+    }
+
+    if (typeof this.panelManager.getButton('options', 'fullscreen') !== 'undefined') {
+      this.panelManager.getButton('options', 'fullscreen').set({
+        className: '',
+        // resets the custom classes, so only displays the default ones and we don't render the icon font anymore
+        label: `<svg ${iconStyle} viewBox="0 0 24 24">
+          <path fill="currentColor" d="M5,5H10V7H7V10H5V5M14,5H19V10H17V7H14V5M17,14H19V19H14V17H17V14M10,17V19H5V14H7V17H10Z" />
+        </svg>`
+      });
+    }
+
+    if (typeof this.panelManager.getButton('options', 'sw-visibility') !== 'undefined') {
+      this.panelManager.getButton('options', 'sw-visibility').set({
+        className: '',
+        // resets the custom classes, so only displays the default ones and we don't render the icon font anymore
+        label: `<svg ${iconStyle} viewBox="0 0 24 24">
+          <path fill="currentColor" d="M15,5H17V3H15M15,21H17V19H15M11,5H13V3H11M19,5H21V3H19M19,9H21V7H19M19,21H21V19H19M19,13H21V11H19M19,17H21V15H19M3,5H5V3H3M3,9H5V7H3M3,13H5V11H3M3,17H5V15H3M3,21H5V19H3M11,21H13V19H11M7,21H9V19H7M7,5H9V3H7V5Z" />
+        </svg>`
+      });
+    }
+  }
+
+}

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -1,6 +1,7 @@
 import DynamicContentBlocks from './dynamicContent/dynamicContent.blocks';
 import ContentService from './content.service';
 import ButtonBlock from './buttonBlock';
+import PanelsMjml from './panels/panels.mjml';
 import BlocksMjml from './blocks/blocks.mjml';
 
 export default (editor, opts = {}) => {
@@ -10,7 +11,9 @@ export default (editor, opts = {}) => {
   const mode = ContentService.getMode(editor);
 
   if (mode === ContentService.modeEmailMjml) {
+    const panelMjml = new PanelsMjml(editor);
     const blockMjml = new BlocksMjml(editor);
+    panelMjml.restylePanels();
     blockMjml.addBlocks();
   }
 

--- a/src/blocks.js
+++ b/src/blocks.js
@@ -24,7 +24,7 @@ export default (editor, opts = {}) => {
   } else {
     // Add Dynamic Content block only for email modes
     const dcb = new DynamicContentBlocks(editor, opts);
-    dcb.addDynamciContentBlock();
+    dcb.addDynamicContentBlock();
   }
 
   // Add icon to mj-hero

--- a/src/blocks/blocks.mjml.js
+++ b/src/blocks/blocks.mjml.js
@@ -15,8 +15,10 @@ export default class BlocksMjml {
     this.blockManager.add('mj-37-columns', {
       label: Mautic.translate('grapesjsbuilder.components.names.twoColumnThirdSevens'),
       category: Mautic.translate('grapesjsbuilder.categorySectionLabel'),
-      attributes: { class: 'gjs-fonts gjs-f-b37' },
       content: `<mj-section>${sections37}</mj-section>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M2 20h5V4H2v16Zm-1 0V4a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1ZM10 20h12V4H10v16Zm-1 0V4a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1v16a1 1 0 0 1-1 1H10a1 1 0 0 1-1-1Z"></path>
+      </svg>`,
     });
 
     const textSect = `<mj-column>
@@ -31,8 +33,10 @@ export default class BlocksMjml {
     this.blockManager.add('text-sect', {
       label: Mautic.translate('grapesjsbuilder.components.names.textSectionBlkLabel'),
       category: Mautic.translate('grapesjsbuilder.reusableDynamicContentBlockLabel'),
-      attributes: { class: 'gjs-fonts gjs-f-h1p' },
       content: `<mj-section>${textSect}</mj-section>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M20,20H4A2,2 0 0,1 2,18V6A2,2 0 0,1 4,4H20A2,2 0 0,1 22,6V18A2,2 0 0,1 20,20M4,6V18H20V6H4M6,9H18V11H6V9M6,13H16V15H6V13Z" />
+      </svg>`,
     });
 
     const gridItem = `<mj-group>
@@ -59,8 +63,10 @@ export default class BlocksMjml {
     this.blockManager.add('grid-items', {
       label: Mautic.translate('grapesjsbuilder.components.names.gridItemsBlkLabel'),
       category: Mautic.translate('grapesjsbuilder.reusableDynamicContentBlockLabel'),
-      attributes: { class: 'fa fa-th' },
       content: `<mj-section>${gridItem}</mj-section>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M3,11H11V3H3M3,21H11V13H3M13,21H21V13H13M13,3V11H21V3"/>
+      </svg>`,
     });
 
     const listItem = `<mj-group>
@@ -80,8 +86,10 @@ export default class BlocksMjml {
     this.blockManager.add('list-items', {
       label: Mautic.translate('grapesjsbuilder.components.names.listItemsBlkLabel'),
       category: Mautic.translate('grapesjsbuilder.reusableDynamicContentBlockLabel'),
-      attributes: { class: 'fa fa-th-list' },
       content: `<mj-section>${listItem}</mj-section>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M2 14H8V20H2M16 8H10V10H16M2 10H8V4H2M10 4V6H22V4M10 20H16V18H10M10 16H22V14H10"/>
+      </svg>`,
     });
   }
 }

--- a/src/buttonBlock.js
+++ b/src/buttonBlock.js
@@ -29,6 +29,9 @@ export default class ButtonBlock {
       },
       content: `${style}
          <a href="#" target="_blank" class="button">Button</a>`,
+      media: `<svg viewBox="0 0 24 24">
+        <path fill="currentColor" d="M20 20.5C20 21.3 19.3 22 18.5 22H13C12.6 22 12.3 21.9 12 21.6L8 17.4L8.7 16.6C8.9 16.4 9.2 16.3 9.5 16.3H9.7L12 18V9C12 8.4 12.4 8 13 8S14 8.4 14 9V13.5L15.2 13.6L19.1 15.8C19.6 16 20 16.6 20 17.1V20.5M20 2H4C2.9 2 2 2.9 2 4V12C2 13.1 2.9 14 4 14H8V12H4V4H20V12H18V14H20C21.1 14 22 13.1 22 12V4C22 2.9 21.1 2 20 2Z" />
+    </svg>`,
     });
   }
 }

--- a/src/buttons.js
+++ b/src/buttons.js
@@ -90,7 +90,6 @@ export default (editor, opts = {}) => {
   btnPreview.addCommand();
   btnPreview.addButton();
 
-
   // add editor apply button
   const btnApply = new ButtonApply(editor);
   btnApply.addCommand();
@@ -136,8 +135,8 @@ export default (editor, opts = {}) => {
       // Add Settings Sector
       const traitsSector = $(
         '<div class="gjs-sm-sector no-select">' +
-        '<div class="gjs-sm-title"><span class="icon-settings fa fa-cog"></span> Settings</div>' +
-        '<div class="gjs-sm-properties" style="display: none;"></div></div>'
+          '<div class="gjs-sm-title"><span class="icon-settings fa fa-cog"></span> Settings</div>' +
+          '<div class="gjs-sm-properties" style="display: none;"></div></div>'
       );
       const traitsProps = traitsSector.find('.gjs-sm-properties');
 

--- a/src/buttons.js
+++ b/src/buttons.js
@@ -139,22 +139,32 @@ export default (editor, opts = {}) => {
           '<div class="gjs-sm-properties" style="display: none;"></div></div>'
       );
       const traitsProps = traitsSector.find('.gjs-sm-properties');
+      const traits = $('.gjs-trt-traits');
 
-      traitsProps.append($('.gjs-trt-traits'));
-      $('.gjs-sm-sectors').before(traitsSector);
-      traitsSector.find('.gjs-sm-title').on('click', () => {
-        const traitStyle = traitsProps.get(0).style;
-        const hidden = traitStyle.display === 'none';
+      // we can only show the Settings, if something in the template is selected
+      // otherwise we're going to get an error about trying to append a non-existing node
+      if (traitsProps.length && traits.length) {
+        traitsProps.append(traits);
 
-        if (hidden) {
-          traitStyle.display = 'block';
-        } else {
-          traitStyle.display = 'none';
+        const sectors = $('.gjs-sm-sectors');
+
+        if (sectors.length) {
+          sectors.before(traitsSector);
+          traitsSector.find('.gjs-sm-title').on('click', () => {
+            const traitStyle = traitsProps.get(0).style;
+            const hidden = traitStyle.display === 'none';
+
+            if (hidden) {
+              traitStyle.display = 'block';
+            } else {
+              traitStyle.display = 'none';
+            }
+          });
+
+          // Open settings
+          traitsProps.get(0).style.display = 'block';
         }
-      });
-
-      // Open settings
-      traitsProps.get(0).style.display = 'block';
+      }
     }
 
     // Open the default panel

--- a/src/buttons.js
+++ b/src/buttons.js
@@ -139,32 +139,21 @@ export default (editor, opts = {}) => {
           '<div class="gjs-sm-properties" style="display: none;"></div></div>'
       );
       const traitsProps = traitsSector.find('.gjs-sm-properties');
-      const traits = $('.gjs-trt-traits');
+      traitsProps.append($('.gjs-trt-traits', '.gjs-traits-cs'));
+      $('.gjs-sm-sectors').before(traitsSector);
+      traitsSector.find('.gjs-sm-title').on('click', () => {
+        const traitStyle = traitsProps.get(0).style;
+        const hidden = traitStyle.display === 'none';
 
-      // we can only show the Settings, if something in the template is selected
-      // otherwise we're going to get an error about trying to append a non-existing node
-      if (traitsProps.length && traits.length) {
-        traitsProps.append(traits);
-
-        const sectors = $('.gjs-sm-sectors');
-
-        if (sectors.length) {
-          sectors.before(traitsSector);
-          traitsSector.find('.gjs-sm-title').on('click', () => {
-            const traitStyle = traitsProps.get(0).style;
-            const hidden = traitStyle.display === 'none';
-
-            if (hidden) {
-              traitStyle.display = 'block';
-            } else {
-              traitStyle.display = 'none';
-            }
-          });
-
-          // Open settings
-          traitsProps.get(0).style.display = 'block';
+        if (hidden) {
+          traitStyle.display = 'block';
+        } else {
+          traitStyle.display = 'none';
         }
-      }
+      });
+
+      // Open settings
+      traitsProps.get(0).style.display = 'block';
     }
 
     // Open the default panel

--- a/src/buttons.js
+++ b/src/buttons.js
@@ -121,17 +121,6 @@ export default (editor, opts = {}) => {
 
     // Load and show settings and style manager
     if (!opts.combineSettingsAndSm) {
-      const openTmBtn = pm.getButton('views', 'open-tm');
-      const openSm = pm.getButton('views', 'open-sm');
-      if (openTmBtn) {
-        openTmBtn.set('active', 1);
-      }
-      if (openSm) {
-        openSm.set('active', 1);
-      }
-
-      pm.removeButton('views', 'open-tm');
-
       // Add Settings Sector
       const traitsSector = $(
         '<div class="gjs-sm-sector no-select">' +
@@ -139,21 +128,37 @@ export default (editor, opts = {}) => {
           '<div class="gjs-sm-properties" style="display: none;"></div></div>'
       );
       const traitsProps = traitsSector.find('.gjs-sm-properties');
-      traitsProps.append($('.gjs-trt-traits', '.gjs-traits-cs'));
-      $('.gjs-sm-sectors').before(traitsSector);
-      traitsSector.find('.gjs-sm-title').on('click', () => {
-        const traitStyle = traitsProps.get(0).style;
-        const hidden = traitStyle.display === 'none';
+      const openTmBtn = pm.getButton('views', 'open-tm');
+      const openSm = pm.getButton('views', 'open-sm');
 
-        if (hidden) {
-          traitStyle.display = 'block';
-        } else {
-          traitStyle.display = 'none';
-        }
-      });
+      if (openTmBtn) {
+        openTmBtn.set('active', 1);
+      }
+      if (openSm) {
+        openSm.set('active', 1);
+      }
+      pm.removeButton('views', 'open-tm');
 
-      // Open settings
-      traitsProps.get(0).style.display = 'block';
+      traitsProps.append($('.gjs-traits-cs'));
+
+      // we can only show the Settings, if something in the template is selected
+      // otherwise we're trying to append stuff to nothing and get errors
+      if ($('.gjs-sm-sectors').length) {
+        $('.gjs-sm-sectors').before(traitsSector);
+        traitsSector.find('.gjs-sm-title').on('click', () => {
+          const traitStyle = traitsProps.get(0).style;
+          const hidden = traitStyle.display === 'none';
+
+          if (hidden) {
+            traitStyle.display = 'block';
+          } else {
+            traitStyle.display = 'none';
+          }
+        });
+
+        // Open settings
+        traitsProps.get(0).style.display = 'block';
+      }
     }
 
     // Open the default panel

--- a/src/dynamicContent/dynamicContent.blocks.js
+++ b/src/dynamicContent/dynamicContent.blocks.js
@@ -11,7 +11,7 @@ export default class DynamicContentBlocks {
     this.blockManager = this.editor.BlockManager;
   }
 
-  addDynamciContentBlock() {
+  addDynamicContentBlock() {
     this.blockManager.add('dynamic-content', {
       label: Mautic.translate('grapesjsbuilder.dynamicContentBlockLabel'),
       activate: true,

--- a/src/dynamicContent/dynamicContent.blocks.js
+++ b/src/dynamicContent/dynamicContent.blocks.js
@@ -22,7 +22,6 @@ export default class DynamicContentBlocks {
       content: {
         type: 'dynamic-content',
         content: '{dynamiccontent="Dynamic Content"}',
-        style: { padding: '10px' },
         activeOnRender: 1,
       },
     });

--- a/src/dynamicContent/dynamicContent.blocks.js
+++ b/src/dynamicContent/dynamicContent.blocks.js
@@ -16,7 +16,9 @@ export default class DynamicContentBlocks {
       label: Mautic.translate('grapesjsbuilder.dynamicContentBlockLabel'),
       activate: true,
       select: true,
-      attributes: { class: 'fa fa-tag' },
+      media: `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512">
+        <path d="M0 80V229.5c0 17 6.7 33.3 18.7 45.3l176 176c25 25 65.5 25 90.5 0L418.7 317.3c25-25 25-65.5 0-90.5l-176-176c-12-12-28.3-18.7-45.3-18.7H48C21.5 32 0 53.5 0 80zm112 32a32 32 0 1 1 0 64 32 32 0 1 1 0-64z"/>
+      </svg>`,
       content: {
         type: 'dynamic-content',
         content: '{dynamiccontent="Dynamic Content"}',

--- a/src/dynamicContent/dynamicContent.commands.js
+++ b/src/dynamicContent/dynamicContent.commands.js
@@ -19,13 +19,16 @@ export default class DynamicContentCommands {
   // eslint-disable-next-line class-methods-use-this
   stopDynamicContentPopup() {
     // Destroy Dynamic Content editors and write the contents to the textarea
-    var logger = this.logger;
-    if (ckEditors != undefined && ckEditors.size > 0) {
-      ckEditors.forEach(function (value, key, map) {
+    const { logger } = this;
+    // eslint-disable-next-line no-undef
+    if (typeof ckEditors !== 'undefined' && ckEditors.size > 0) {
+      // eslint-disable-next-line no-undef
+      ckEditors.forEach((value, key, map) => {
         const name = key.id;
         if (name.includes('dynamicContent')) {
           logger.debug(`Destroying Dynamic Content editor: ${name}`);
           map.get(key).destroy();
+          // eslint-disable-next-line no-undef
           ckEditors.delete(key);
         }
       });

--- a/src/dynamicContent/dynamicContent.commands.js
+++ b/src/dynamicContent/dynamicContent.commands.js
@@ -19,7 +19,8 @@ export default class DynamicContentCommands {
   // eslint-disable-next-line class-methods-use-this
   stopDynamicContentPopup() {
     // Destroy Dynamic Content editors and write the contents to the textarea
-    const { logger } = this;
+    // eslint-disable-next-line prefer-destructuring
+    const logger = this.logger;
     // eslint-disable-next-line no-undef
     if (typeof ckEditors !== 'undefined' && ckEditors.size > 0) {
       // eslint-disable-next-line no-undef

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -25,8 +25,8 @@ export default class DynamicContentDomComponents {
         },
       },
       /**
-        * Initilize the component
-        */
+       * Initilize the component
+       */
       init() {
         // link component to the corresponding html store item
         this.em
@@ -61,7 +61,7 @@ export default class DynamicContentDomComponents {
           };
         }
         return false;
-      }
+      },
     };
 
     const view = {

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -10,66 +10,61 @@ export default class DynamicContentDomComponents {
     const tagName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'div';
     const baseType = dc.getType(baseTypeName);
     const baseModel = baseType.model;
-    const model = baseModel.extend(
-      {
-        defaults: {
-          ...baseModel.prototype.defaults,
-          name: 'Dynamic Content',
-          tagName,
-          draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
-          droppable: false,
-          editable: false,
-          stylable: false,
-          propagate: ['droppable', 'editable'],
-          attributes: {
-            'data-gjs-type': 'dynamic-content', // Type for GrapesJS
-            'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation
-          },
+    const model = {
+      defaults: {
+        name: 'Dynamic Content',
+        tagName,
+        draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
+        droppable: false,
+        editable: false,
+        stylable: false,
+        propagate: ['droppable', 'editable'],
+        attributes: {
+          'data-gjs-type': 'dynamic-content', // Type for GrapesJS
+          'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation
         },
-        /**
-         * Initilize the component
-         */
-        init() {
-          // link component to the corresponding html store item
-          this.em
-            .get('Commands')
-            .run('preset-mautic:link-component-to-store-item', { component: this });
-
-          // Add toolbar edit button if it's not already in
-          const toolbar = this.get('toolbar');
-          const id = 'toolbar-dynamic-content';
-
-          if (!toolbar.filter((tlb) => tlb.id === id).length) {
-            toolbar.unshift({
-              id,
-              command: 'preset-mautic:dynamic-content-open',
-              attributes: { class: 'fa fa-pencil-square-o' },
-            });
-          }
-        },
-        // @todo: show the store items default content on the canvas
-        // updated(property, value, prevValue) {
-        //   console.log('Local hook: model.updated', {
-        //     property,
-        //     value,
-        //     prevValue,
-        //   });
-        // },
       },
-      {
-        // Dynamic Content component detection
-        isComponent(el) {
-          if (el.getAttribute && el.getAttribute('data-slot') === 'dynamicContent') {
-            return {
-              type: 'dynamic-content',
-            };
-          }
-          return false;
-        },
-      }
-    );
+      /**
+        * Initilize the component
+        */
+      init() {
+        // link component to the corresponding html store item
+        this.em
+          .get('Commands')
+          .run('preset-mautic:link-component-to-store-item', { component: this });
 
-    const view = baseType.view.extend({
+        // Add toolbar edit button if it's not already in
+        const toolbar = this.get('toolbar');
+        const id = 'toolbar-dynamic-content';
+
+        if (!toolbar.filter((tlb) => tlb.id === id).length) {
+          toolbar.unshift({
+            id,
+            command: 'preset-mautic:dynamic-content-open',
+            attributes: { class: 'fa fa-pencil-square-o' },
+          });
+        }
+      },
+      // @todo: show the store items default content on the canvas
+      // updated(property, value, prevValue) {
+      //   console.log('Local hook: model.updated', {
+      //     property,
+      //     value,
+      //     prevValue,
+      //   });
+      // },
+      // Dynamic Content component detection
+      isComponent(el) {
+        if (el.getAttribute && el.getAttribute('data-slot') === 'dynamicContent') {
+          return {
+            type: 'dynamic-content',
+          };
+        }
+        return false;
+      }
+    };
+
+    const view = {
       attributes: {
         style: 'pointer-events: all; display: table; width: 100%;user-select: none;',
       },
@@ -98,7 +93,7 @@ export default class DynamicContentDomComponents {
       //     .get('Commands')
       //     .run('preset-mautic:dynamic-content-delete-store-item', { component });
       // },
-    });
+    };
 
     // add the Dynamic Content component
     dc.addType('dynamic-content', {

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -19,7 +19,7 @@ export default class DynamicContentDomComponents {
       editable: false,
       stylable: false,
       propagate: ['droppable', 'editable'],
-      style: baseModel.prototype.defaults['style-default'],
+      style: { ...baseModel.prototype.defaults['style-default'], ...{ display: 'block' } },
       attributes: {
         'data-gjs-type': 'dynamic-content', // Type for GrapesJS
         'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -79,8 +79,10 @@ export default class DynamicContentDomComponents {
         const dcService = new DynamicContentService(editor);
         const decId = DynamicContentService.getDataParamDecid(el.model);
         const dcItem = dcService.getStoreItem(decId);
-        this.el.innerHTML = dcItem.content;
-        dcService.logger.debug('DC: Updated view', dcItem);
+        if (typeof dcItem !== 'undefined') {
+          this.el.innerHTML = dcItem.content;
+          dcService.logger.debug('DC: Updated view', dcItem);
+        }
       },
       // open the dynamic content modal if the editor is added or double clicked
       onActive() {

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -75,9 +75,10 @@ export default class DynamicContentDomComponents {
         dblclick: 'onActive',
       },
       // replace token with human readable view
-      onRender(el) {
+      // eslint-disable-next-line no-shadow
+      onRender({ editor, model }) {
         const dcService = new DynamicContentService(editor);
-        const decId = DynamicContentService.getDataParamDecid(el.model);
+        const decId = DynamicContentService.getDataParamDecid(model);
         const dcItem = dcService.getStoreItem(decId);
         if (typeof dcItem !== 'undefined') {
           this.el.innerHTML = dcItem.content;

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -45,23 +45,6 @@ export default class DynamicContentDomComponents {
           });
         }
       },
-      // @todo: show the store items default content on the canvas
-      // updated(property, value, prevValue) {
-      //   console.log('Local hook: model.updated', {
-      //     property,
-      //     value,
-      //     prevValue,
-      //   });
-      // },
-      // Dynamic Content component detection
-      isComponent(el) {
-        if (el.getAttribute && el.getAttribute('data-slot') === 'dynamicContent') {
-          return {
-            type: 'dynamic-content',
-          };
-        }
-        return false;
-      },
     };
 
     const view = {
@@ -97,6 +80,18 @@ export default class DynamicContentDomComponents {
 
     // add the Dynamic Content component
     dc.addType('dynamic-content', {
+      // Dynamic Content component detection
+      isComponent: (el) => {
+        if (
+          typeof el.getAttribute !== 'undefined' &&
+          el.getAttribute('data-slot') === 'dynamicContent'
+        ) {
+          return {
+            type: 'dynamic-content',
+          };
+        }
+        return false;
+      },
       model,
       view,
     });

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -68,6 +68,14 @@ export default class DynamicContentDomComponents {
         // open the editor in the popup
         this.em.get('Commands').run('preset-mautic:dynamic-content-open', { target });
       },
+      // @todo: show the store items default content on the canvas
+      // updated(property, value, prevValue) {
+      //   console.log('Local hook: model.updated', {
+      //     property,
+      //     value,
+      //     prevValue,
+      //   });
+      // },
       // does not work: gets removed when Sorting (by grapesjs)
       // removed() {
       //   // Delete dynamic-content on Mautic side

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -14,7 +14,7 @@ export default class DynamicContentDomComponents {
       defaults: {
         name: 'Dynamic Content',
         tagName,
-        draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
+        draggable: '[data-gjs-type="cell"],[data-gjs-type="mj-column"]',
         droppable: false,
         editable: false,
         stylable: false,

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -19,6 +19,7 @@ export default class DynamicContentDomComponents {
       editable: false,
       stylable: false,
       propagate: ['droppable', 'editable'],
+      style: baseModel.prototype.defaults['style-default'],
       attributes: {
         'data-gjs-type': 'dynamic-content', // Type for GrapesJS
         'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -10,20 +10,23 @@ export default class DynamicContentDomComponents {
     const tagName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'div';
     const baseType = dc.getType(baseTypeName);
     const baseModel = baseType.model;
-    const model = {
-      defaults: {
-        name: 'Dynamic Content',
-        tagName,
-        draggable: '[data-gjs-type="cell"],[data-gjs-type="mj-column"]',
-        droppable: false,
-        editable: false,
-        stylable: false,
-        propagate: ['droppable', 'editable'],
-        attributes: {
-          'data-gjs-type': 'dynamic-content', // Type for GrapesJS
-          'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation
-        },
+
+    const dynamicContentModel = {
+      name: 'Dynamic Content',
+      tagName,
+      draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
+      droppable: false,
+      editable: false,
+      stylable: false,
+      propagate: ['droppable', 'editable'],
+      attributes: {
+        'data-gjs-type': 'dynamic-content', // Type for GrapesJS
+        'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation
       },
+    };
+
+    const model = {
+      defaults: { ...baseModel.prototype.defaults, ...dynamicContentModel },
       /**
        * Initilize the component
        */

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -49,6 +49,22 @@ export default class DynamicContentDomComponents {
           });
         }
       },
+      // @todo: show the store items default content on the canvas
+      // updated(property, value, prevValue) {
+      //   console.debug('Local hook: model.updated', {
+      //     property,
+      //     value,
+      //     prevValue,
+      //   });
+      // },
+      // does not work: gets removed when Sorting (by grapesjs)
+      // removed() {
+      //   // Delete dynamic-content on Mautic side
+      //   const component = this.model;
+      //   this.em
+      //     .get('Commands')
+      //     .run('preset-mautic:dynamic-content-delete-store-item', { component });
+      // },
     };
 
     const view = {
@@ -72,22 +88,6 @@ export default class DynamicContentDomComponents {
         // open the editor in the popup
         this.em.get('Commands').run('preset-mautic:dynamic-content-open', { target });
       },
-      // @todo: show the store items default content on the canvas
-      // updated(property, value, prevValue) {
-      //   console.log('Local hook: model.updated', {
-      //     property,
-      //     value,
-      //     prevValue,
-      //   });
-      // },
-      // does not work: gets removed when Sorting (by grapesjs)
-      // removed() {
-      //   // Delete dynamic-content on Mautic side
-      //   const component = this.model;
-      //   this.em
-      //     .get('Commands')
-      //     .run('preset-mautic:dynamic-content-delete-store-item', { component });
-      // },
     };
 
     // add the Dynamic Content component

--- a/src/dynamicContent/dynamicContent.events.js
+++ b/src/dynamicContent/dynamicContent.events.js
@@ -17,7 +17,7 @@ export default class DynamicContentEvents {
   onComponentRemove() {
     this.editor.on('component:remove', (component) => {
       // Delete dynamic-content on Mautic side
-      if (component.get('type') === 'dynamic-content') {
+      if (component === this.editor.getSelected() && component.get('type') === 'dynamic-content') {
         this.editor.runCommand('preset-mautic:dynamic-content-delete-store-item', { component });
       }
     });

--- a/src/editorFonts/editorFonts.service.js
+++ b/src/editorFonts/editorFonts.service.js
@@ -38,7 +38,10 @@ export default class EditorFontsService {
     const canvasHead = editor.Canvas.getDocument().head;
 
     mauticEditorFonts.forEach((item) => {
-      if (!fontList.find((element) => element.name === item.name)) {
+      let key = 'name';
+      if (propertyType === 'options') key = 'label';
+
+      if (!fontList.find((element) => element[key] === item.name)) {
         if (propertyType === 'list') fontList.push({ value: item.font, name: item.name });
         if (propertyType === 'options') fontList.push({ id: item.font, label: item.name });
 

--- a/src/editorFonts/editorFonts.service.js
+++ b/src/editorFonts/editorFonts.service.js
@@ -17,20 +17,30 @@ export default class EditorFontsService {
       return;
     }
 
-    const fontList = fontProperty.get('list');
-    EditorFontsService.updateFontList(editor, fontList);
-    EditorFontsService.sortFontList(fontList);
+    // first check if we have the 'list' property to work with
+    let propertyType = 'list';
+    let fontList = fontProperty.get('list');
 
-    fontProperty.set('list', fontList);
+    // use 'options' if 'list' doesn't exist
+    if (typeof fontList === 'undefined') {
+      propertyType = 'options';
+      fontList = fontProperty.get('options');
+    }
+
+    EditorFontsService.updateFontList(editor, fontList, propertyType);
+    EditorFontsService.sortFontList(fontList, propertyType);
+
+    fontProperty.set(propertyType, fontList);
     styleManager.render();
   }
 
-  static updateFontList(editor, fontList) {
+  static updateFontList(editor, fontList, propertyType) {
     const canvasHead = editor.Canvas.getDocument().head;
 
     mauticEditorFonts.forEach((item) => {
       if (!fontList.find((element) => element.name === item.name)) {
-        fontList.push({ value: item.font, name: item.name });
+        if (propertyType === 'list') fontList.push({ value: item.font, name: item.name });
+        if (propertyType === 'options') fontList.push({ id: item.font, label: item.name });
 
         if (item.url && canvasHead) {
           EditorFontsService.appendFontStyleLink(canvasHead, item.url);
@@ -41,8 +51,9 @@ export default class EditorFontsService {
     return fontList;
   }
 
-  static sortFontList(fontList) {
-    fontList.sort((a, b) => (a.name < b.name ? -1 : 1));
+  static sortFontList(fontList, propertyType) {
+    if (propertyType === 'list') fontList.sort((a, b) => (a.name < b.name ? -1 : 1));
+    if (propertyType === 'options') fontList.sort((a, b) => (a.label < b.label ? -1 : 1));
 
     return fontList;
   }

--- a/src/panels/panels.mjml.js
+++ b/src/panels/panels.mjml.js
@@ -1,0 +1,50 @@
+export default class PanelsMjml {
+  panelManager;
+
+  editor;
+
+  constructor(editor) {
+    this.editor = editor;
+    this.panelManager = editor.Panels;
+  }
+
+  restylePanels() {
+    const iconStyle = 'style="display: block; max-width: 22px"';
+
+    if (typeof this.panelManager.getButton('views', 'open-blocks') !== 'undefined') {
+      this.panelManager.getButton('views', 'open-blocks').set({
+        className: '', // resets the custom classes, so only displays the default ones and we don't render the icon font anymore
+        label: `<svg ${iconStyle} viewBox="0 0 24 24">
+          <path fill="currentColor" d="M17,13H13V17H11V13H7V11H11V7H13V11H17M19,3H5C3.89,3 3,3.89 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V5C21,3.89 20.1,3 19,3Z" />
+        </svg>`,
+      });
+    }
+
+    if (typeof this.panelManager.getButton('views', 'open-sm') !== 'undefined') {
+      this.panelManager.getButton('views', 'open-sm').set({
+        className: '', // resets the custom classes, so only displays the default ones and we don't render the icon font anymore
+        label: `<svg style="display: block; max-width: 22px" viewBox="0 0 24 24">
+          <path fill="currentColor" d="M20.71,4.63L19.37,3.29C19,2.9 18.35,2.9 17.96,3.29L9,12.25L11.75,15L20.71,6.04C21.1,5.65 21.1,5 20.71,4.63M7,14A3,3 0 0,0 4,17C4,18.31 2.84,19 2,19C2.92,20.22 4.5,21 6,21A4,4 0 0,0 10,17A3,3 0 0,0 7,14Z" />
+        </svg>`,
+      });
+    }
+
+    if (typeof this.panelManager.getButton('options', 'fullscreen') !== 'undefined') {
+      this.panelManager.getButton('options', 'fullscreen').set({
+        className: '', // resets the custom classes, so only displays the default ones and we don't render the icon font anymore
+        label: `<svg ${iconStyle} viewBox="0 0 24 24">
+          <path fill="currentColor" d="M5,5H10V7H7V10H5V5M14,5H19V10H17V7H14V5M17,14H19V19H14V17H17V14M10,17V19H5V14H7V17H10Z" />
+        </svg>`,
+      });
+    }
+
+    if (typeof this.panelManager.getButton('options', 'sw-visibility') !== 'undefined') {
+      this.panelManager.getButton('options', 'sw-visibility').set({
+        className: '', // resets the custom classes, so only displays the default ones and we don't render the icon font anymore
+        label: `<svg ${iconStyle} viewBox="0 0 24 24">
+          <path fill="currentColor" d="M15,5H17V3H15M15,21H17V19H15M11,5H13V3H11M19,5H21V3H19M19,9H21V7H19M19,21H21V19H19M19,13H21V11H19M19,17H21V15H19M3,5H5V3H3M3,9H5V7H3M3,13H5V11H3M3,17H5V15H3M3,21H5V19H3M11,21H13V19H11M7,21H9V19H7M7,5H9V3H7V5Z" />
+        </svg>`,
+      });
+    }
+  }
+}


### PR DESCRIPTION
Registering your custom components using the legacy method breaks when updating GrapesJS to [release 0.20.1](https://github.com/GrapesJS/grapesjs/releases/tag/v0.20.1). Need this to be able to upgrade GrapesJS in the GrapesJSBuilderBundle.

[Here is a PR for Mautic 4](https://github.com/mautic/grapesjs-preset-mautic/pull/50)

To test:
* have a Mautic 5.x running locally
* replace the package with my forked branch in plugins/GrapesJsBuilderBundle, eg. by running `npm i grapesjs-preset- mautic@github:LordRembo/grapesjs-preset-mautic#update-grapesjs-m5` inside that bundle
* rebuilding GrapesJs bundle by running `npm run build`
* Make or edit an email and see that you can still use drag & drop to add/move/edit a Dynamic content Block.
* Check that there are no new JS errors
* You should still be able to save that edited mail