### PR TITLE
Prevent dynamic content block removal when closing and reopening the editor

### DIFF
--- a/dist/dynamicContent/dynamicContent.events.js
+++ b/dist/dynamicContent/dynamicContent.events.js
@@ -17,7 +17,7 @@ export default class DynamicContentEvents {
   onComponentRemove() {
     this.editor.on('component:remove', component => {
       // Delete dynamic-content on Mautic side
-      if (component.get('type') === 'dynamic-content') {
+      if (component === this.editor.getSelected() && component.get('type') === 'dynamic-content') {
         this.editor.runCommand('preset-mautic:dynamic-content-delete-store-item', {
           component
         });

--- a/src/dynamicContent/dynamicContent.events.js
+++ b/src/dynamicContent/dynamicContent.events.js
@@ -17,7 +17,7 @@ export default class DynamicContentEvents {
   onComponentRemove() {
     this.editor.on('component:remove', (component) => {
       // Delete dynamic-content on Mautic side
-      if (component.get('type') === 'dynamic-content') {
+      if (component === this.editor.getSelected() && component.get('type') === 'dynamic-content') {
         this.editor.runCommand('preset-mautic:dynamic-content-delete-store-item', { component });
       }
     });


### PR DESCRIPTION
In certain cases, as described in [this ticket 13612 on Mautic](https://github.com/mautic/mautic/pull/13612), a Dynamic Content block loses its ID reference when closing the Builder. So when reopening, you can't edit it anymore or it is showing `{dynamiccontent = "undefined"}`.
This fix adds an extra check and so removal only happens when trashing the block.

This fix is also a part of [a bigger update PR](https://github.com/mautic/grapesjs-preset-mautic/pull/49) I've prepared. So you can see it being fixed, by testing that PR.