### PR TITLE
fix urls for column image placeholders

### DIFF
--- a/dist/blocks/blocks.mjml.js
+++ b/dist/blocks/blocks.mjml.js
@@ -39,7 +39,7 @@ export default class BlocksMjml {
     });
     const gridItem = `<mj-group>
         <mj-column>
-          <mj-image height="auto" src="https://via.placeholder.com/172x215/#7f7f7f/ffffff?text=172x215+x2"></mj-image>
+          <mj-image height="auto" src="https://via.placeholder.com/172x215/7f7f7f/ffffff?text=172x215+x2"></mj-image>
           <mj-text font-size="18px" font-weight="bold" align="center">
             Insert title here
           </mj-text>
@@ -48,7 +48,7 @@ export default class BlocksMjml {
           </mj-text>
         </mj-column>
         <mj-column>
-          <mj-image height="auto" src="https://via.placeholder.com/172x215/#7f7f7f/ffffff?text=172x215+x2"></mj-image>
+          <mj-image height="auto" src="https://via.placeholder.com/172x215/7f7f7f/ffffff?text=172x215+x2"></mj-image>
           <mj-text font-size="18px" font-weight="bold" align="center">
             Insert title here
           </mj-text>
@@ -67,7 +67,7 @@ export default class BlocksMjml {
     });
     const listItem = `<mj-group>
         <mj-column width="30%">
-          <mj-image height="auto" src="https://via.placeholder.com/172x215/#7f7f7f/ffffff?text=172x215+x2"></mj-image>
+          <mj-image height="auto" src="https://via.placeholder.com/172x215/7f7f7f/ffffff?text=172x215+x2"></mj-image>
         </mj-column>
         <mj-column width="70%">
           <mj-text font-size="18px" font-weight="bold" align="center">

--- a/src/blocks/blocks.mjml.js
+++ b/src/blocks/blocks.mjml.js
@@ -41,7 +41,7 @@ export default class BlocksMjml {
 
     const gridItem = `<mj-group>
         <mj-column>
-          <mj-image height="auto" src="https://via.placeholder.com/172x215/#7f7f7f/ffffff?text=172x215+x2"></mj-image>
+          <mj-image height="auto" src="https://via.placeholder.com/172x215/7f7f7f/ffffff?text=172x215+x2"></mj-image>
           <mj-text font-size="18px" font-weight="bold" align="center">
             Insert title here
           </mj-text>
@@ -50,7 +50,7 @@ export default class BlocksMjml {
           </mj-text>
         </mj-column>
         <mj-column>
-          <mj-image height="auto" src="https://via.placeholder.com/172x215/#7f7f7f/ffffff?text=172x215+x2"></mj-image>
+          <mj-image height="auto" src="https://via.placeholder.com/172x215/7f7f7f/ffffff?text=172x215+x2"></mj-image>
           <mj-text font-size="18px" font-weight="bold" align="center">
             Insert title here
           </mj-text>
@@ -71,7 +71,7 @@ export default class BlocksMjml {
 
     const listItem = `<mj-group>
         <mj-column width="30%">
-          <mj-image height="auto" src="https://via.placeholder.com/172x215/#7f7f7f/ffffff?text=172x215+x2"></mj-image>
+          <mj-image height="auto" src="https://via.placeholder.com/172x215/7f7f7f/ffffff?text=172x215+x2"></mj-image>
         </mj-column>
         <mj-column width="70%">
           <mj-text font-size="18px" font-weight="bold" align="center">


### PR DESCRIPTION
This fixes the rendering of the placeholder images in the Grid. There should not be a `#` in there.