### PR TITLE
Fix for Mautic issue #14288 - Multiple dynamic content blocks show multiple editors #14288

### DIFF
--- a/dist/dynamicContent/dynamicContent.commands.js
+++ b/dist/dynamicContent/dynamicContent.commands.js
@@ -35,6 +35,17 @@ export default class DynamicContentCommands {
           ckEditors.delete(key);
         }
       });
+    } // empty the listeners, these are created when reopening
+    // otherwise the listeners are compounded and we get multiple CKEditors 
+    // for 1 textarea
+
+
+    if (Mautic.internalDynamicContentItemCreateListeners && Mautic.internalDynamicContentItemCreateListeners.length) {
+      Mautic.internalDynamicContentItemCreateListeners = [];
+    }
+
+    if (Mautic.internalDynamicContentFilterCreateListeners && Mautic.internalDynamicContentFilterCreateListeners.length) {
+      Mautic.internalDynamicContentFilterCreateListeners = [];
     }
 
     this.dcService.updateDcStoreItem();

--- a/src/dynamicContent/dynamicContent.commands.js
+++ b/src/dynamicContent/dynamicContent.commands.js
@@ -35,6 +35,22 @@ export default class DynamicContentCommands {
       });
     }
 
+    // empty the listeners, these are created when reopening
+    // otherwise the listeners are compounded and we get multiple CKEditors 
+    // for 1 textarea
+    if (
+      Mautic.internalDynamicContentItemCreateListeners &&
+      Mautic.internalDynamicContentItemCreateListeners.length
+    ) {
+      Mautic.internalDynamicContentItemCreateListeners = [];
+    }
+    if (
+      Mautic.internalDynamicContentFilterCreateListeners &&
+      Mautic.internalDynamicContentFilterCreateListeners.length
+    ) {
+      Mautic.internalDynamicContentFilterCreateListeners = [];
+    }
+
     this.dcService.updateDcStoreItem();
   }
 


### PR DESCRIPTION
This change makes sure to clear out the array that keeps track of the listeners responsible for creating new CKEditors for the textareas inside the Dynamic Content popup.
Every time a variant is added, a new textarea exists and this needs to have a new CKEditor. However, the list of listeners was never cleared when closing the popup. This had the downside or adding new listeners every time the popup was reopened (eg. to edit it). So every new Variant you openend, created the same CKEditor as before + a new one.

https://github.com/mautic/mautic/issues/14288

**To test:**

1. Have you Mautic test project ready
2. inside the GrapesJS Plugin (`plugins/GrapesJsBuilderBundle`), replace the `grapesjs-preset-mautic` node module with the version [from this merge request](https://github.com/LordRembo/grapesjs-preset-mautic/tree/fix/dynamic-content-multiple-editors): `npm i grapesjs-preset-mautic@github:LordRembo/grapesjs-preset-mautic/tree/fix/dynamic-content-multiple-editors`
3. Rebuild the GrapesJS Plugin javascript using `npm run rebuild` (still in `plugins/GrapesJsBuilderBundle`)
