### PR TITLE
Fix: Prevent head content duplication in code edit mode

### DIFF
--- a/dist/content.service.js
+++ b/dist/content.service.js
@@ -39,8 +39,20 @@ export default class ContentService {
      * (as it's passed by reference), so we don't need to re-assign anything here
      */
 
-    Mautic.sanitizeHtmlBeforeSave(mQuery(originalContent));
-    const htmlCombined = `${doctype}<html>${editor.getHtml()}<style>${editor.getCss({
+    Mautic.sanitizeHtmlBeforeSave(mQuery(originalContent)); // Get the HTML content from editor - need to extract body content only to avoid
+    // duplicating head content when using code edit mode
+
+    const editorHtml = editor.getHtml();
+    let bodyContent = editorHtml; // Parse the editor HTML to extract only body content
+    // This handles the case where code edit mode might have loaded full HTML documents
+
+    const tempDoc = parser.parseFromString(`<html><body>${editorHtml}</body></html>`, 'text/html');
+
+    if (tempDoc.body) {
+      bodyContent = tempDoc.body.innerHTML;
+    }
+
+    const htmlCombined = `${doctype}<html><head></head><body>${bodyContent}</body><style>${editor.getCss({
       avoidProtected: true
     })}</style></html>`; // get a DocumentHTML from the string
 

--- a/src/content.service.js
+++ b/src/content.service.js
@@ -49,7 +49,19 @@ export default class ContentService {
      */
     Mautic.sanitizeHtmlBeforeSave(mQuery(originalContent));
 
-    const htmlCombined = `${doctype}<html>${editor.getHtml()}<style>${editor.getCss({
+    // Get the HTML content from editor - need to extract body content only to avoid
+    // duplicating head content when using code edit mode
+    const editorHtml = editor.getHtml();
+    let bodyContent = editorHtml;
+
+    // Parse the editor HTML to extract only body content
+    // This handles the case where code edit mode might have loaded full HTML documents
+    const tempDoc = parser.parseFromString(`<html><body>${editorHtml}</body></html>`, 'text/html');
+    if (tempDoc.body) {
+      bodyContent = tempDoc.body.innerHTML;
+    }
+
+    const htmlCombined = `${doctype}<html><head></head><body>${bodyContent}</body><style>${editor.getCss({
       avoidProtected: true,
     })}</style></html>`;
 


### PR DESCRIPTION
When using the code edit mode in the Landing Page Builder, the head content was being duplicated into the body. This fix ensures that only the body content is extracted from the editor HTML, preventing the duplication issue.

Fix for: Landing Page Builder duplicates <head> content into <body> when using code edit mode