### PR TITLE
Fix: Prevent head content duplication in landing pages (Issue #14409)

### DIFF
--- a/src/content.service.js
+++ b/src/content.service.js
@@ -49,7 +49,13 @@ export default class ContentService {
      */
     Mautic.sanitizeHtmlBeforeSave(mQuery(originalContent));
 
-    const htmlCombined = `${doctype}<html>${editor.getHtml()}<style>${editor.getCss({
+    // FIX for issue #14409: Extract body content from editor HTML to prevent head duplication
+    // editor.getHtml() may return complete HTML document (with head/body) after code edit mode
+    const editorHtml = editor.getHtml();
+    const editorDoc = parser.parseFromString(editorHtml, 'text/html');
+    const bodyContent = editorDoc.body ? editorDoc.body.innerHTML : editorHtml;
+
+    const htmlCombined = `${doctype}<html>${bodyContent}<style>${editor.getCss({
       avoidProtected: true,
     })}</style></html>`;
 


### PR DESCRIPTION
## Bug Description
Code Editor in Landing Pages Duplicates \ Content into the \ Section

Fixes https://github.com/mautic/mautic/issues/14409

## Root Cause
When using code edit mode in the GrapeJS builder, \ returns a complete HTML document (including \ and \). This caused the head content to be incorrectly placed inside the body when the HTML was reparsed.

## Fix
Extract only the body content from \ before combining it with the template:

\\\<html>\<style>...\\

## Changes
- Modified \ in \
- Added body content extraction to prevent head duplication

## Testing
- [ ] Create a new landing page using the "Blank" theme
- [ ] Switch to code edit mode and click save
- [ ] Verify that \ content does not appear in \
- [ ] Repeat saving multiple times - no cumulative duplication

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are minimal and focused
- [x] Related issue linked