### PR TITLE
Fix Dynamic content rendering and spacing issues

### DIFF
--- a/src/dynamicContent/dynamicContent.commands.js
+++ b/src/dynamicContent/dynamicContent.commands.js
@@ -1,5 +1,4 @@
 import Logger from '../logger';
-import MjmlService from '../mjml/mjml.service';
 import DynamicContentService from './dynamicContent.service';
 
 export default class DynamicContentCommands {
@@ -95,14 +94,10 @@ export default class DynamicContentCommands {
       const dynConTarget = mQuery(dynConId);
       const dynConName = dynConTarget.find(`${dynConId}_tokenName`).val();
       const dynConToken = `{dynamiccontent="${dynConName}"}`;
-
-      // Clear id because it's reloaded by Mautic and this prevent slot to be destroyed by GrapesJs destroy event on close.
-      // dynamicContent.addAttributes({ 'data-param-dec-id': '' });
       this.logger.debug("DC: Replaced component's content with its token", {
         dynamicContent,
         dynConToken,
       });
-      dynamicContent.components('');
       dynamicContent.set('content', dynConToken);
     });
 

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -1,123 +1,180 @@
+import ContentService from '../content.service';
 import DynamicContentService from './dynamicContent.service';
 
-export default class DynamicContentDomComponents {
-  dcService;
+const DC_TYPE = 'dynamic-content';
+const DC_SLOT = 'dynamicContent';
+const TOOLBAR_ID = 'toolbar-dynamic-content';
+const OPEN_COMMAND = 'preset-mautic:dynamic-content-open';
+const LINK_COMMAND = 'preset-mautic:link-component-to-store-item';
 
+function isDynamicContentComponent(el) {
+  if (typeof el.getAttribute !== 'undefined' && el.getAttribute('data-slot') === DC_SLOT) {
+    return {
+      type: DC_TYPE,
+    };
+  }
+  return false;
+}
+
+function addToolbarAndLink(component) {
+  component.em.get('Commands').run(LINK_COMMAND, { component });
+
+  const toolbar = component.get('toolbar') || [];
+
+  if (!toolbar.some((item) => item.id === TOOLBAR_ID)) {
+    toolbar.unshift({
+      id: TOOLBAR_ID,
+      command: OPEN_COMMAND,
+      attributes: { class: 'fa fa-pencil-square-o' },
+    });
+  }
+
+  component.set('toolbar', toolbar);
+}
+
+function renderDynamicContent(editor, model, renderContent, loggerContext = 'DC: Updated view') {
+  const dcService = new DynamicContentService(editor);
+  const dynamicContentId = DynamicContentService.getDataParamDecid(model);
+  const dcItem = dcService.getStoreItem(dynamicContentId);
+
+  if (dcItem) {
+    renderContent(dcItem.content);
+    dcService.logger.debug(loggerContext, dcItem);
+  }
+}
+
+export default class DynamicContentDomComponents {
   static addDynamicContentType(editor) {
     const dc = editor.DomComponents;
-    const baseType = dc.getType('mj-text');
-    const baseModel = baseType.model;
+    const isMjml = ContentService.isMjmlMode(editor);
 
-    // Keep style-default from mj-text so padding etc. render correctly via MJML
-    // compilation. Do not spread baseModel attributes — coreMjmlModel.init() will
-    // re-derive them from style-default, avoiding duplicate style props as raw
-    // HTML attributes on the saved <mj-text> element.
-    const styleDefault = baseModel.prototype.defaults['style-default'];
+    if (isMjml) {
+      const baseType = dc.getType('mj-text');
+      const baseModel = baseType.model;
 
-    const model = {
-      defaults: {
-        ...baseModel.prototype.defaults,
-        name: 'Dynamic Content',
-        tagName: 'mj-text',
-        draggable: '[data-gjs-type=mj-column]',
-        droppable: false,
-        editable: false,
-        stylable: ['padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left'],
-        propagate: ['droppable', 'editable'],
-        'style-default': styleDefault,
-        attributes: {
-          'data-gjs-type': 'dynamic-content', // Type for GrapesJS
-          'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation
+      // Keep style-default from mj-text so padding etc. render correctly via MJML
+      // compilation. Do not spread baseModel attributes — coreMjmlModel.init() will
+      // re-derive them from style-default, avoiding duplicate style props as raw
+      // HTML attributes on the saved <mj-text> element.
+      const styleDefault = baseModel.prototype.defaults['style-default'];
+
+      const model = {
+        defaults: {
+          ...baseModel.prototype.defaults,
+          name: 'Dynamic Content',
+          tagName: 'mj-text',
+          draggable: '[data-gjs-type=mj-column]',
+          droppable: false,
+          editable: false,
+          stylable: ['padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left'],
+          propagate: ['droppable', 'editable'],
+          'style-default': styleDefault,
+          attributes: {
+            'data-gjs-type': DC_TYPE, // Type for GrapesJS
+            'data-slot': DC_SLOT, // used to find the DC component on the canvas for e.g. token transformation
+          },
         },
-      },
-      /**
-       * Initilize the component
-       */
-      init() {
-        // coreMjmlModel.init() syncs style-default into attributes and style
-        if (typeof baseModel.prototype.init === 'function') {
-          baseModel.prototype.init.call(this);
-        }
-
-        // link component to the corresponding html store item
-        this.em
-          .get('Commands')
-          .run('preset-mautic:link-component-to-store-item', { component: this });
-
-        // Add toolbar edit button if it's not already in
-        const toolbar = this.get('toolbar');
-        const id = 'toolbar-dynamic-content';
-
-        if (!toolbar.filter((tlb) => tlb.id === id).length) {
-          toolbar.unshift({
-            id,
-            command: 'preset-mautic:dynamic-content-open',
-            attributes: { class: 'fa fa-pencil-square-o' },
-          });
-        }
-      },
-    };
-
-    // Extend mj-text's view to inherit the full MJML rendering pipeline:
-    // tagName:'tr', getTemplateFromMjml, renderChildren, renderStyle, etc.
-    const view = {
-      tagName: 'tr',
-      attributes: {
-        style: 'pointer-events: all; display: table; width: 100%; user-select: none;',
-      },
-      getMjmlTemplate() {
-        return {
-          start: `<mjml><mj-body><mj-column>`,
-          end: `</mj-column></mj-body></mjml>`,
-        };
-      },
-      getTemplateFromEl(sandboxEl) {
-        return sandboxEl.querySelector('tr').innerHTML;
-      },
-      getChildrenSelector() {
-        return 'td > div';
-      },
-      rerender() {
-        this.render();
-      },
-      // After the MJML pipeline renders the <tr> shell, replace the inner
-      // content with the DC item's human-readable HTML.
-      onRender({ editor, model }) {
-        const dcService = new DynamicContentService(editor);
-        const decId = DynamicContentService.getDataParamDecid(model);
-        const dcItem = dcService.getStoreItem(decId);
-        if (typeof dcItem !== 'undefined') {
-          const container = this.el.querySelector('td > div') || this.el.querySelector('td');
-          if (container) {
-            container.innerHTML = dcItem.content;
+        init() {
+          // coreMjmlModel.init() syncs style-default into attributes and style
+          if (typeof baseModel.prototype.init === 'function') {
+            baseModel.prototype.init.call(this);
           }
-          dcService.logger.debug('DC: Updated view', dcItem);
-        }
-      },
-      onActive() {
-        const target = this.model;
-        this.em.get('Commands').run('preset-mautic:dynamic-content-open', { target });
-      },
-    };
+          addToolbarAndLink(this);
+        },
+      };
 
-    // add the Dynamic Content component
-    dc.addType('dynamic-content', {
-      extend: 'mj-text',
-      extendFnView: ['onActive'],
-      // Dynamic Content component detection
-      isComponent: (el) => {
-        if (
-          typeof el.getAttribute !== 'undefined' &&
-          el.getAttribute('data-slot') === 'dynamicContent'
-        ) {
+      const view = {
+        tagName: 'tr',
+        attributes: {
+          style: 'pointer-events: all; display: table; width: 100%; user-select: none;',
+        },
+        getMjmlTemplate() {
           return {
-            type: 'dynamic-content',
+            start: '<mjml><mj-body><mj-column>',
+            end: '</mj-column></mj-body></mjml>',
           };
-        }
-        return false;
-      },
-      model,
-      view,
-    });
+        },
+        getTemplateFromEl(sandboxEl) {
+          const row = sandboxEl.querySelector('tr');
+          return row ? row.innerHTML : '';
+        },
+        getChildrenSelector() {
+          return 'td > div';
+        },
+        rerender() {
+          this.render();
+        },
+        // After the MJML pipeline renders the <tr> shell, replace the inner
+        // content with the DC item's human-readable HTML.
+        onRender({ editor, model }) {
+          renderDynamicContent(editor, model, (content) => {
+            const container = this.el.querySelector('td > div') || this.el.querySelector('td');
+            if (container) {
+              container.innerHTML = content;
+            }
+          });
+        },
+        onActive() {
+          this.em.get('Commands').run(OPEN_COMMAND, { target: this.model });
+        },
+      };
+
+      // add the Dynamic Content component
+      dc.addType(DC_TYPE, {
+        extend: 'mj-text',
+        extendFnView: ['onActive'],
+        // Dynamic Content component detection
+        isComponent: isDynamicContentComponent,
+        model,
+        view,
+      });
+    } else {
+      const baseType = dc.getType('text');
+      const baseModel = baseType.model;
+
+      const model = {
+        defaults: {
+          ...baseModel.prototype.defaults,
+          name: 'Dynamic Content',
+          tagName: 'div',
+          draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
+          droppable: false,
+          editable: false,
+          stylable: ['padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left'],
+          propagate: ['droppable', 'editable'],
+          style: { ...baseModel.prototype.defaults['style-default'], display: 'block' },
+          attributes: {
+            'data-gjs-type': DC_TYPE,
+            'data-slot': DC_SLOT,
+          },
+        },
+        init() {
+          addToolbarAndLink(this);
+        },
+      };
+
+      const view = {
+        attributes: {
+          style: 'pointer-events: all; display: table; width: 100%; user-select: none;',
+        },
+        events: {
+          dblclick: 'onActive',
+        },
+        onRender({ editor, model }) {
+          renderDynamicContent(editor, model, (content) => {
+            this.el.innerHTML = content;
+          });
+        },
+        onActive() {
+          this.em.get('Commands').run(OPEN_COMMAND, { target: this.model });
+        },
+      };
+
+      dc.addType(DC_TYPE, {
+        isComponent: isDynamicContentComponent,
+        model,
+        view,
+      });
+    }
   }
 }

--- a/src/dynamicContent/dynamicContent.domcomponents.js
+++ b/src/dynamicContent/dynamicContent.domcomponents.js
@@ -1,4 +1,3 @@
-import ContentService from '../content.service';
 import DynamicContentService from './dynamicContent.service';
 
 export default class DynamicContentDomComponents {
@@ -6,32 +5,40 @@ export default class DynamicContentDomComponents {
 
   static addDynamicContentType(editor) {
     const dc = editor.DomComponents;
-    const baseTypeName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'text';
-    const tagName = ContentService.isMjmlMode(editor) ? 'mj-text' : 'div';
-    const baseType = dc.getType(baseTypeName);
+    const baseType = dc.getType('mj-text');
     const baseModel = baseType.model;
 
-    const dynamicContentModel = {
-      name: 'Dynamic Content',
-      tagName,
-      draggable: '[data-gjs-type=cell],[data-gjs-type=mj-column]',
-      droppable: false,
-      editable: false,
-      stylable: false,
-      propagate: ['droppable', 'editable'],
-      style: { ...baseModel.prototype.defaults['style-default'], ...{ display: 'block' } },
-      attributes: {
-        'data-gjs-type': 'dynamic-content', // Type for GrapesJS
-        'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation
-      },
-    };
+    // Keep style-default from mj-text so padding etc. render correctly via MJML
+    // compilation. Do not spread baseModel attributes — coreMjmlModel.init() will
+    // re-derive them from style-default, avoiding duplicate style props as raw
+    // HTML attributes on the saved <mj-text> element.
+    const styleDefault = baseModel.prototype.defaults['style-default'];
 
     const model = {
-      defaults: { ...baseModel.prototype.defaults, ...dynamicContentModel },
+      defaults: {
+        ...baseModel.prototype.defaults,
+        name: 'Dynamic Content',
+        tagName: 'mj-text',
+        draggable: '[data-gjs-type=mj-column]',
+        droppable: false,
+        editable: false,
+        stylable: ['padding', 'padding-top', 'padding-right', 'padding-bottom', 'padding-left'],
+        propagate: ['droppable', 'editable'],
+        'style-default': styleDefault,
+        attributes: {
+          'data-gjs-type': 'dynamic-content', // Type for GrapesJS
+          'data-slot': 'dynamicContent', // used to find the DC component on the canvas for e.g. token transformation
+        },
+      },
       /**
        * Initilize the component
        */
       init() {
+        // coreMjmlModel.init() syncs style-default into attributes and style
+        if (typeof baseModel.prototype.init === 'function') {
+          baseModel.prototype.init.call(this);
+        }
+
         // link component to the corresponding html store item
         this.em
           .get('Commands')
@@ -49,52 +56,54 @@ export default class DynamicContentDomComponents {
           });
         }
       },
-      // @todo: show the store items default content on the canvas
-      // updated(property, value, prevValue) {
-      //   console.debug('Local hook: model.updated', {
-      //     property,
-      //     value,
-      //     prevValue,
-      //   });
-      // },
-      // does not work: gets removed when Sorting (by grapesjs)
-      // removed() {
-      //   // Delete dynamic-content on Mautic side
-      //   const component = this.model;
-      //   this.em
-      //     .get('Commands')
-      //     .run('preset-mautic:dynamic-content-delete-store-item', { component });
-      // },
     };
 
+    // Extend mj-text's view to inherit the full MJML rendering pipeline:
+    // tagName:'tr', getTemplateFromMjml, renderChildren, renderStyle, etc.
     const view = {
+      tagName: 'tr',
       attributes: {
-        style: 'pointer-events: all; display: table; width: 100%;user-select: none;',
+        style: 'pointer-events: all; display: table; width: 100%; user-select: none;',
       },
-      events: {
-        dblclick: 'onActive',
+      getMjmlTemplate() {
+        return {
+          start: `<mjml><mj-body><mj-column>`,
+          end: `</mj-column></mj-body></mjml>`,
+        };
       },
-      // replace token with human readable view
-      // eslint-disable-next-line no-shadow
+      getTemplateFromEl(sandboxEl) {
+        return sandboxEl.querySelector('tr').innerHTML;
+      },
+      getChildrenSelector() {
+        return 'td > div';
+      },
+      rerender() {
+        this.render();
+      },
+      // After the MJML pipeline renders the <tr> shell, replace the inner
+      // content with the DC item's human-readable HTML.
       onRender({ editor, model }) {
         const dcService = new DynamicContentService(editor);
         const decId = DynamicContentService.getDataParamDecid(model);
         const dcItem = dcService.getStoreItem(decId);
         if (typeof dcItem !== 'undefined') {
-          this.el.innerHTML = dcItem.content;
+          const container = this.el.querySelector('td > div') || this.el.querySelector('td');
+          if (container) {
+            container.innerHTML = dcItem.content;
+          }
           dcService.logger.debug('DC: Updated view', dcItem);
         }
       },
-      // open the dynamic content modal if the editor is added or double clicked
       onActive() {
         const target = this.model;
-        // open the editor in the popup
         this.em.get('Commands').run('preset-mautic:dynamic-content-open', { target });
       },
     };
 
     // add the Dynamic Content component
     dc.addType('dynamic-content', {
+      extend: 'mj-text',
+      extendFnView: ['onActive'],
       // Dynamic Content component detection
       isComponent: (el) => {
         if (


### PR DESCRIPTION
Fix dynamic content functionality in the GrapeJS Mautic preset:
- Fix dynamic content MJML rendering by restructuring the DOM component rendering logic
- Prevent dynamic content from disappearing after save by removing problematic command handlers
- Add option to edit the padding of the dynamic content element:
<img width="957" height="417" alt="image" src="https://github.com/user-attachments/assets/f1213bbe-19dc-4aa3-b00d-10762db054fa" />

Closes [#15209](https://github.com/mautic/mautic/issues/15209)

## Test plan
- Create a new email with dynamic content blocks
- Verify dynamic content displays correctly in the editor
- Save the email and confirm dynamic content persists
- Test MJML rendering of dynamic content blocks (preview the email or send it)
- Verify no console errors related to dynamic content commands

## How to test with Mautic:

<details>
<summary><strong>Option 1: Developer Setup (Recommended for Testing)</strong></summary>

This approach allows you to work with the latest source code directly and make additional changes if needed.

#### Prerequisites

- Git installed
- Node.js and npm installed
- Mautic instance running locally
- Terminal/command line knowledge

#### Steps

1. **Clone the repositories side by side**

   Navigate to your projects directory (e.g., `~/projects`) and clone both repos:

   ```bash
   cd ~/projects

   # Clone Mautic (if you don't have it yet)
   git clone https://github.com/mautic/mautic.git

   # Clone the preset with the fix branch
   git clone --branch MTC-8602_dwc-padding-issues git@github.com:patrykgruszka/grapesjs-preset-mautic.git
   ```

   Your directory structure should look like:
   ```
   ~/projects/
   ├── mautic/
   └── grapesjs-preset-mautic/
   ```

2. **Update Mautic to use local preset**

   Edit `mautic/plugins/GrapesJsBuilderBundle/Assets/library/js/builder.service.js`:

   - **Comment out** lines 14-15 (the npm package imports):
     ```js
     // import contentService from 'grapesjs-preset-mautic/dist/content.service';
     // import grapesjsmautic from 'grapesjs-preset-mautic';
     ```

   - **Uncomment** lines 20-21 (the local imports):
     ```js
     import contentService from '../../../../../../grapesjs-preset-mautic/src/content.service';
     import grapesjsmautic from '../../../../../../grapesjs-preset-mautic/src';
     ```

   Full diff:
   ```diff
   -import contentService from 'grapesjs-preset-mautic/dist/content.service';
   -import grapesjsmautic from 'grapesjs-preset-mautic';
   +// import contentService from 'grapesjs-preset-mautic/dist/content.service';
   +// import grapesjsmautic from 'grapesjs-preset-mautic';
    import editorFontsService from 'grapesjs-preset-mautic/dist/editorFonts/editorFonts.service';
    import StorageService from './storage.service';

    // for local dev
   -// import contentService from '../../../../../../grapesjs-preset-mautic/src/content.service';
   -// import grapesjsmautic from '../../../../../../grapesjs-preset-mautic/src';
   +import contentService from '../../../../../../grapesjs-preset-mautic/src/content.service';
   +import grapesjsmautic from '../../../../../../grapesjs-preset-mautic/src';
   ```

3. **Build the plugin**

   ```bash
   cd mautic/plugins/GrapesJsBuilderBundle
   npm run rebuild
   ```

4. **Clear Mautic cache**

   ```bash
   cd mautic

   # For development
   php bin/console cache:clear

   # Or if using DDEV
   ddev php bin/console cache:clear
   ```

5. **Test the changes**

   - Open your Mautic email builder: `https://your-mautic-instance/s/emails`
   - Create a new email and add dynamic content
   - Save the email
   - Verify that dynamic content persists after save
   - Test MJML rendering by switching to code view

</details>

<details>
<summary><strong>Option 2: Pre-built Distribution File (For Non-Technical Users)</strong></summary>

This approach uses a pre-built version of the preset without needing Node.js or build tools.

#### Prerequisites
- Mautic instance running locally

#### Steps

1. **Download the pre-built file**

   Download the builder file from the release:
   - [builder.js](https://github.com/user-attachments/files/26829936/builder.js)


2. **Replace the file in your Mautic installation**

   Navigate to your Mautic directory and replace the builder file:
   ```bash
   cp ~/Downloads/builder.js \
     mautic/plugins/GrapesJsBuilderBundle/Assets/library/js/dist/builder.js
   ```

   Or manually:
   - Open file explorer/finder
   - Navigate to `mautic/plugins/GrapesJsBuilderBundle/Assets/library/js/dist/`
   - Replace `builder.js` with the downloaded file

3. **Clear Browser cache**

4. **Test the changes**

</details>
