### PR TITLE
Fix dynamic content duplication when cloning MJML email

### DIFF
--- a/dist/dynamicContent/dynamicContent.commands.js
+++ b/dist/dynamicContent/dynamicContent.commands.js
@@ -101,6 +101,8 @@ export default class DynamicContentCommands {
         dynamicContent,
         dynConToken
       });
+      dynamicContent.components(''); // prevents dynamic content duplication on clone/save
+
       dynamicContent.set('content', dynConToken);
     });
     return dynamicContents.length;

--- a/src/dynamicContent/dynamicContent.commands.js
+++ b/src/dynamicContent/dynamicContent.commands.js
@@ -98,6 +98,7 @@ export default class DynamicContentCommands {
         dynamicContent,
         dynConToken,
       });
+      dynamicContent.components(''); // prevents dynamic content duplication on clone/save
       dynamicContent.set('content', dynConToken);
     });
 


### PR DESCRIPTION
Restores `dynamicContent. components('')` - a cleanup, which was removed in https://github.com/mautic/grapesjs-preset-mautic/pull/60.

Without clearing the existing children, the mj-text-based dynamic-content component retains the human-readable text from parsed MJML and emits it alongside the token on save, causing duplication like:

```
<mj-text ...>Dynamic Content 2{dynamiccontent="Dynamic Content 2"}</mj-text>
```